### PR TITLE
Added release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,63 @@
+name: Release
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Branch/tag/hash to use (defaults to master)
+        required: false
+        default: master
+      product:
+        description: Product for which the plugin will be released (jira/confluence/bitbucket)
+        required: true
+      artifactory-user:
+        description: Artifactory user
+        required: true
+      artifactory-password:
+        description: Artifactory password
+        required: true
+      release-version:
+        description: Version to release (defaults to next micro version)
+      next-development-version:
+        description: Next development version (default to next snapshot micro version)
+
+jobs:
+  log-params:
+    name: Log Params
+    runs-on: ubuntu-latest
+    steps:
+      # don't log password as part of the a whole inputs object
+      - run: |
+          echo 'Ref [${{ github.event.inputs.ref }}].'
+          echo 'Product [${{ github.event.inputs.product }}].'
+          echo 'Artifactory user [${{ github.event.inputs.artifactory-user }}].'
+          echo 'Release version [${{ github.event.inputs.release-version }}].'
+          echo 'Next development version [${{ github.event.inputs.next-development-version }}].'
+
+  release-plugin:
+    name: Release Plugin
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      # make credentials accessible during the release by copying them to environment variables
+      ARTIFACTORY_USER: ${{ github.event.inputs.artifactory-user }}
+      ARTIFACTORY_PASSWORD: ${{ github.event.inputs.artifactory-password }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.ref }}
+      # fail job fast in case of invalid product
+      - run: bin/build/populate-plugin-by-product.sh ${{ github.event.inputs.product }}
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - run: bin/build/install-plugin-sdk.sh
+      - run: bin/build/configure-maven-for-release.sh
+      - uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: maven-release
+          restore-keys: |
+            maven-
+      - run: bin/build/install-common-modules.sh
+      - run: bin/build/release-single-plugin.sh
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,14 +15,16 @@ jobs:
   log-params:
     name: Log Params
     runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - run: echo 'Github event inputs [${{ toJson(github.event.inputs) }}].'
+      - run: echo 'Head commit message [${{ github.event.head_commit.message }}].'
 
   unit-tests:
     name: Unit Tests
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    if: github.event.inputs.jobs == '' || contains(github.event.inputs.jobs, 'unit-tests')
+    if: "(github.event.inputs.jobs == '' || contains(github.event.inputs.jobs, 'unit-tests')) && !contains(github.event.head_commit.message, '[skip ci]')"
     strategy:
       matrix:
         java-version: [8, 11]

--- a/README.md
+++ b/README.md
@@ -103,6 +103,15 @@ Run integration tests for Bitbucket plugin:
 bin/build/run-bitbucket-its.sh
 ```
 
+# CI/CD
+## Tests
+Unit and integration tests are run on each commit by Github Actions. See [test.yml](.github/workflows/test.yml) for more details.
+A specific test job may be run manually on any branch from **"Actions"** tab on the repo page.
+
+## Releasing
+Release workflow allows to publish new releases to [Atlassian Artifactory](https://packages.atlassian.com/). 
+This action should be usually be run by repo maintainer only. See workflow configuration in [release.yml](.github/workflows/release.yml).
+
 # Contributions
 
 Contributions to Atlassian Server Integrations for Slack project are welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for details.

--- a/bin/build/configure-maven-for-release.sh
+++ b/bin/build/configure-maven-for-release.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -ex
+trap 'set +ex' EXIT
+
+MAVEN_HOME=$(atlas-version | grep 'ATLAS Maven Home' | grep -oE '/.+$')
+
+# Add atlassian maven servers to deploy releases there
+# maven-atlassian-com is defined in parent POM: com.atlassian.pom:public-pom:5.0.26
+sudo sed -i'backupServer' '/<servers>/ a\
+<server><id>maven-atlassian-com</id><username>${env.ARTIFACTORY_USER}</username><password>${env.ARTIFACTORY_PASSWORD}</password></server>' $MAVEN_HOME/conf/settings.xml

--- a/bin/build/populate-plugin-by-product.sh
+++ b/bin/build/populate-plugin-by-product.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -ex
+trap 'set +ex' EXIT
+
+case "$1" in
+  jira)
+    echo "::set-env name=PLUGIN::jira-slack-server-integration/jira-slack-server-integration-plugin"
+    ;;
+  confluence)
+    echo "::set-env name=PLUGIN::confluence-slack-server-integration-plugin"
+    ;;
+  bitbucket)
+    echo "::set-env name=PLUGIN::bitbucket-slack-server-integration-plugin"
+    ;;
+  *)
+    echo "No plugin found for product [$1]"
+    exit 1
+esac

--- a/bin/build/release-single-plugin.sh
+++ b/bin/build/release-single-plugin.sh
@@ -5,20 +5,14 @@ trap 'set +ex' EXIT
 RELEASE_VERSION_ARG=$([[ -z $RELEASE_VERSION ]] && echo "" || echo "-DreleaseVersion=$RELEASE_VERSION")
 DEVELOPMENT_VERSION_ARG=$([[ -z $DEVELOPMENT_VERSION ]] && echo "" || echo "-DdevelopmentVersion=$DEVELOPMENT_VERSION")
 
-mvn release:prepare release:perform --show-version --batch-mode \
+MAVEN_HOME=$(atlas-version | grep 'ATLAS Maven Home' | grep -oE '/.+$')
+
+# atlas-mvn or atlas-release fails with "Unknown lifecycle phase ci]" error
+$MAVEN_HOME/bin/mvn -gs ${MAVEN_HOME}/conf/settings.xml release:prepare release:perform \
+    --show-version \
+    --batch-mode \
     -Dmaven.test.skip=true \
-    -Darguments=-Dmaven.test.skip=true --activate-profiles include-common \
+    -Darguments="-Dmaven.test.skip=true --activate-profiles include-common" \
     -DscmCommentPrefix="[skip ci] " \
     --activate-profiles include-common \
     --projects "${PLUGIN}" ${RELEASE_VERSION_ARG} ${DEVELOPMENT_VERSION_ARG}
-
-echo "
-       ___  ______   _______   ___________
-      / _ \/ __/ /  / __/ _ | / __/ __/ _ \\
-     / , _/ _// /__/ _// __ |_\ \/ _// // /
-    /_/|_/___/____/___/_/ |_/___/___/____/
-
-    https://packages.atlassian.com/maven-public-local/com/atlassian/${NAME}/plugins/${NAME}-slack-server-integration-plugin/${RELEASE_VERSION}/${NAME}-slack-server-integration-plugin-${RELEASE_VERSION}.jar
-
-"
-


### PR DESCRIPTION
Here is a generic release flow for all 3 plugins. It is flexible enough to handle that.
Job receives 6 parameters:
* ref - branch to be released. Most of the time it should be `master`. In fact I don't think that any other branch will ever be used, I added this part of logic just because it was already implemented for tests workflow.
* product - jira/confluence/bitbucket. It gets translated to a valid Maven module name during the job execution.
* artifactory-user
* artifactory-password - credentials for Artifactory. It might be better to place it to encrypted repo secrets once we ensure that only Atlassian staff is allowed to trigger manual jobs like this.
* release-version
* next-development-version - optional versions, which may be specified to release any non-bugfix version. By default Maven release plugin increments bugfix version if these parameters are not passed. Works in 90% of cases.

I tested release workflow only in "dry mode" - with no real tagging and artifacts uploads. After the merge of this PR I'll try to publish a test release for one of the products.