### PR TITLE
Removed unused dependencies that Dependabot has concerns about

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,6 @@
         <analytics-api.version>3.15</analytics-api.version>
         <slf4j.version>1.7.25</slf4j.version>
         <sal.api.version>3.1.0</sal.api.version>
-        <log4j.version>1.2.17</log4j.version>
         <mockito-core.version>2.25.0</mockito-core.version>
         <junit.version>4.12</junit.version>
         <junit.jupiter.version>5.5.1</junit.jupiter.version>
@@ -188,16 +187,6 @@
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
                 <version>${slf4j.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-log4j12</artifactId>
-                <version>${slf4j.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>log4j</groupId>
-                <artifactId>log4j</artifactId>
-                <version>${log4j.version}</version>
             </dependency>
             <dependency>
                 <groupId>joda-time</groupId>


### PR DESCRIPTION
These dependencies were included into parent pom.xml, but weren't actually used in any of the sub-modules. It is safe to delete them to please Dependabot.