### PR TITLE
Release checker respect closed issues

### DIFF
--- a/.github/workflows/all-tests.yml
+++ b/.github/workflows/all-tests.yml
@@ -8,7 +8,7 @@ on:
         required: false
         default: master
       jobs:
-        description: Jobs to run (defaults to all)
+        description: Jobs to run (comma-separated, defaults to all)
         required: false
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ Use tool `./bitbucket.sh` for all dev cycle. It has a similar set of commands to
 
 # Documentation
 
-Links to the official documentation are specified on plugin Marketplace pages (see **Usage** section).
+Links to the official documentation are specified on plugin Marketplace pages (see **Usage** section). 
+This is [the same link](https://confluence.atlassian.com/slack/atlassian-for-slack-integrations-967327515.html).
 
 ## Development References
 
@@ -110,8 +111,16 @@ bin/build/run-bitbucket-its.sh
 
 # CI/CD
 ## Tests
-Unit and integration tests are run on each commit by Github Actions. See [test.yml](.github/workflows/test.yml) for more details.
-A specific test job may be run manually on any branch from **"Actions"** tab on the repo page.
+Unit and integration tests against the oldest and newest supported product versions are run on each commit by Github Actions.
+See [all-tests.yml](.github/workflows/all-tests.yml) for more details. A specific test job may be run manually on any branch from 
+**"Actions"** tab on the repo page by specifying `ref` and `jobs` arguments.
+
+Note: all integration test jobs in default workflow (`all-tests.yml`) are dependent on unit tests, so to run integration tests
+for specific product pass the respective job's name along with `unit-test` to `jobs` parameter. For example: `unit-tests,integration-tests-jira-8`.
+
+Integration tests for arbitrary verions of the the product and JVM may be run manually using 
+[jira-int-tests.yml](.github/workflows/jira-int-tests.yml), [confluence-int-tests.yml](.github/workflows/confluence-int-tests.yml)
+and [bitbucket-int-tests.yml](.github/workflows/bitbucket-int-tests.yml).
 
 ## Releasing
 Release workflow allows to publish new releases to [Atlassian Artifactory](https://packages.atlassian.com/). 

--- a/bin/pack-common.sh
+++ b/bin/pack-common.sh
@@ -2,7 +2,7 @@
 
 (
     cd "$( dirname "${BASH_SOURCE[0]}")/.." ;
-    mvn install --batch-mode -Dmaven.test.skip=true \
+    atlas-mvn install --batch-mode -Dmaven.test.skip=true \
         "$@" \
         -pl com.atlassian.plugins:atlassian-slack-server-integration-parent,jira-slack-server-integration,slack-server-integration-common,slack-server-integration-test-common && \
     rm -rf jira-slack-server-integration/jira-slack-server-integration-plugin/target/classes/com/atlassian/plugins/slack && \

--- a/bin/pack-compat-jira.sh
+++ b/bin/pack-compat-jira.sh
@@ -2,7 +2,7 @@
 
 (
     cd "$( dirname "${BASH_SOURCE[0]}")/.." ;
-    mvn install --batch-mode -Dmaven.test.skip=true "$@" -pl com.atlassian.plugins:jira-8-compat,com.atlassian.plugins:jira-service-desk-compat,com.atlassian.plugins:jira-service-desk-compat-common,com.atlassian.plugins:jira-service-desk-3-compat,com.atlassian.plugins:jira-service-desk-4-compat,com.atlassian.plugins:jira-service-desk-compat-main && \
+    atlas-mvn install --batch-mode -Dmaven.test.skip=true "$@" -pl com.atlassian.plugins:jira-8-compat,com.atlassian.plugins:jira-service-desk-compat,com.atlassian.plugins:jira-service-desk-compat-common,com.atlassian.plugins:jira-service-desk-3-compat,com.atlassian.plugins:jira-service-desk-4-compat,com.atlassian.plugins:jira-service-desk-compat-main && \
     rm -rf jira-slack-server-integration/jira-slack-server-integration-plugin/target/classes/com/atlassian/plugin/slack/jira/compat && \
     rm -f jira-slack-server-integration/jira-slack-server-integration-plugin/target/dependency-maven-plugin-markers/com.atlassian.plugins-jira-8-compat-jar-*
 )

--- a/bin/pack-plugin.sh
+++ b/bin/pack-plugin.sh
@@ -2,7 +2,7 @@
 
 (
     cd "$( dirname "${BASH_SOURCE[0]}")/.." ;
-    mvn package --batch-mode \
+    atlas-mvn package --batch-mode \
         -Dmaven.test.skip=true \
         --activate-profiles include-common \
         "$@" \

--- a/bin/release-check/fetch-release-issue.sh
+++ b/bin/release-check/fetch-release-issue.sh
@@ -5,9 +5,9 @@ release_label="${RELEASE_LABEL:?Please set RELEASE_LABEL.}"
 
 # CHECK AN ISSUE LABELED WITH VERSION ALREADY EXISTS
 
-# QUERY JIRA FOR LABEL
+# QUERY GITHUB FOR ISSUE WITH LABEL (INCLUDING CLOSED ISSUES)
 issue_for_version_response=$(curl -s \
-  "https://api.github.com/repos/atlassian-labs/atlassian-slack-integration-server/issues?labels=$release_label")
+  "https://api.github.com/repos/atlassian-labs/atlassian-slack-integration-server/issues?labels=$release_label&state=all")
 
 # CHECK WHETHER AT LEAST ONE RESULT ITEM IS FOUND
 has_issue_for_version=$(echo "$issue_for_version_response" | jq -r 'length > 0')

--- a/bin/run-bitbucket-its.sh
+++ b/bin/run-bitbucket-its.sh
@@ -6,7 +6,7 @@ BASE_URL="http://127.0.0.1:7990/bitbucket"
 (
     cd "$( dirname "${BASH_SOURCE[0]}")/.." ;
 
-    mvn --batch-mode verify \
+    atlas-mvn --batch-mode verify \
       -Dut.test.skip=true \
       -Dit.test.skip=false \
       -Dapp.startup.skip=true \

--- a/bin/run-bitbucket.sh
+++ b/bin/run-bitbucket.sh
@@ -12,7 +12,7 @@ BB_NGROK="$(curl -s "http://127.0.0.1:4040/api/tunnels" | \
 
     # set env var BB_NGROK to enable HTTPS
 
-    mvn bitbucket:debug \
+    atlas-mvn bitbucket:debug \
         -Datlassian.dev.mode=true \
         -Dmaven.test.skip=true \
         -Dlogging.level.com.atlassian.bitbucket.plugins.slack=TRACE \

--- a/bin/run-confluence.sh
+++ b/bin/run-confluence.sh
@@ -2,7 +2,7 @@
 
 (
     cd "$( dirname "${BASH_SOURCE[0]}")/.." ;
-    mvn confluence:debug \
+    atlas-mvn confluence:debug \
         -Datlassian.dev.mode=true \
         -Dmaven.test.skip=true \
         "$@" \

--- a/bin/run-jira.sh
+++ b/bin/run-jira.sh
@@ -2,7 +2,7 @@
 
 (
     cd "$( dirname "${BASH_SOURCE[0]}")/.." ;
-    mvn jira:debug \
+    atlas-mvn jira:debug \
         -Datlassian.dev.mode=true \
         -Dmaven.test.skip=true \
         "$@" \

--- a/bin/test-with-coverage.sh
+++ b/bin/test-with-coverage.sh
@@ -3,5 +3,5 @@
 echo "Make sure you have releases common project and define proper versions of dependencies"
 (
     cd "$( dirname "${BASH_SOURCE[0]}")/.." ;
-    mvn --batch-mode verify -P jacoco
+    atlas-mvn --batch-mode verify -P jacoco
 )

--- a/bitbucket.sh
+++ b/bitbucket.sh
@@ -54,8 +54,8 @@ export PLUGIN="bitbucket-slack-server-integration-plugin"
 (
     cd "$( dirname "${BASH_SOURCE[0]}")" ;
     [[ "$help" == "yes" ]] && echo "${HELP_TEXT}" ;
-    ([[ "$clean" != "yes" ]] || mvn clean) && \
-    ([[ "$purge" != "yes" ]] || (rm -rf ${PLUGIN}/target && mvn clean)) && \
+    ([[ "$clean" != "yes" ]] || atlas-mvn clean) && \
+    ([[ "$purge" != "yes" ]] || (rm -rf ${PLUGIN}/target && atlas-mvn clean)) && \
     ([[ "$common" != "yes" ]] || ./bin/pack-common.sh) && \
     ([[ "$deps" != "yes" ]] || (rm -f ${PLUGIN}/target/dependency-maven-plugin-markers/*.marker && rm -rf ${PLUGIN}/target/classes)) && \
     ([[ "$pack" != "yes" ]] || ./bin/pack-plugin.sh) && \

--- a/confluence-slack-server-integration-plugin/src/test/java/it/com/atlassian/confluence/plugins/slack/web/ConfigurationWebTest.java
+++ b/confluence-slack-server-integration-plugin/src/test/java/it/com/atlassian/confluence/plugins/slack/web/ConfigurationWebTest.java
@@ -90,7 +90,8 @@ public class ConfigurationWebTest extends SlackWebTestBase {
 
         mapping.get().clickTrashButton();
 
-        Poller.waitUntilFalse(Conditions.forSupplier(() ->
+        int twoSecondsTimeout = 2 * 1000;
+        Poller.waitUntilFalse(Conditions.forSupplier(twoSecondsTimeout, () ->
                 findMappingRow(configurationSection.getMappingTable(), PUBLIC.getId()).isPresent()));
     }
 

--- a/confluence.sh
+++ b/confluence.sh
@@ -51,8 +51,8 @@ export PLUGIN="confluence-slack-server-integration-plugin"
 (
     cd "$( dirname "${BASH_SOURCE[0]}")" ;
     [[ "$help" == "yes" ]] && echo "${HELP_TEXT}" ;
-    ([[ "$clean" != "yes" ]] || mvn clean) && \
-    ([[ "$purge" != "yes" ]] || (rm -rf ${PLUGIN}/target && mvn clean)) && \
+    ([[ "$clean" != "yes" ]] || atlas-mvn clean) && \
+    ([[ "$purge" != "yes" ]] || (rm -rf ${PLUGIN}/target && atlas-mvn clean)) && \
     ([[ "$common" != "yes" ]] || ./bin/pack-common.sh) && \
     ([[ "$deps" != "yes" ]] || (rm -f ${PLUGIN}/target/dependency-maven-plugin-markers/*.marker && rm -rf ${PLUGIN}/target/classes)) && \
     ([[ "$pack" != "yes" ]] || bin/pack-plugin.sh) && \

--- a/jira.sh
+++ b/jira.sh
@@ -57,8 +57,8 @@ export PLUGIN="jira-slack-server-integration/jira-slack-server-integration-plugi
 (
     cd "$( dirname "${BASH_SOURCE[0]}")" ;
     [[ "$help" == "yes" ]] && echo "${HELP_TEXT}" ;
-    ([[ "$clean" != "yes" ]] || mvn clean) && \
-    ([[ "$purge" != "yes" ]] || (rm -rf ${PLUGIN}/target && mvn clean)) && \
+    ([[ "$clean" != "yes" ]] || atlas-mvn clean) && \
+    ([[ "$purge" != "yes" ]] || (rm -rf ${PLUGIN}/target && atlas-mvn clean)) && \
     ([[ "$common" != "yes" ]] || ./bin/pack-common.sh) && \
     ([[ "$compat" != "yes" ]] || ./bin/pack-compat-jira.sh) && \
     ([[ "$deps" != "yes" ]] || (rm -f ${PLUGIN}/target/dependency-maven-plugin-markers/*.marker && rm -rf ${PLUGIN}/target/classes)) && \


### PR DESCRIPTION
1. Release checker now can look for closed issues with specified label. Apparently, documentation misses that only open issues are searched by default: https://docs.github.com/en/rest/reference/issues#list-repository-issues.
2. Replaced `mvn` in the scripts used in dev loop with `atlas-mvn` like it was done previously in build scripts run by CI.