### PR TITLE
Update 'connect [Slack] workspace' link to create a new classic app

### DIFF
--- a/slack-server-integration-common/src/main/resources/admin/connect/connect-workspace.js
+++ b/slack-server-integration-common/src/main/resources/admin/connect/connect-workspace.js
@@ -110,7 +110,7 @@ require([
                         window.open("https://slack.com/apps/" + AJS.I18n.getText('slack.blueprint.app.id'));
                     } else {
                         var appId = goToSlackButton.data('app-id') || "";
-                        window.open("https://api.slack.com/apps" + (appId ? "/" + appId : "?new_app=1"));
+                        window.open("https://api.slack.com/apps" + (appId ? "/" + appId : "?new_classic_app=1"));
                     }
                 });
 


### PR DESCRIPTION
The current link to https://api.slack.com/apps?new_app=1 takes the user to create a new application however the current integration requires [what's considered a "classic" Slack app](https://api.slack.com/authentication/quickstart) which can be created by going to https://api.slack.com/apps?new_classic_app=1 instead.

![image](https://user-images.githubusercontent.com/34566/89576871-b6f13d80-d7e4-11ea-982f-306782dcfbca.png)

---

- [x] Slack has signed the [Atlassian Corporate CLA](https://na2.docusign.net/Member/PowerFormSigning.aspx?PowerFormId=e1c17c66-ca4d-4aab-a953-2c231af4a20b)