### PR TITLE
#45: Bumped latest supported Jira version to 8.12.2

### DIFF
--- a/.github/workflows/all-tests.yml
+++ b/.github/workflows/all-tests.yml
@@ -81,7 +81,7 @@ jobs:
           path: jira-slack-server-integration/jira-slack-server-integration-plugin/target/webdriverTests/**
 
   integration-tests-jira-8:
-    name: Integration Tests - Jira 8.11.0
+    name: Integration Tests - Jira 8.12.2
     runs-on: ubuntu-latest
     timeout-minutes: 15
     if: github.event.inputs.jobs == '' || contains(github.event.inputs.jobs, 'integration-tests-jira-8')
@@ -106,13 +106,13 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: ~/.m2/repository/com/atlassian/jira
-          key: maven-integration-jira-8.11.0
+          key: maven-integration-jira-8.12.2
       - run: bin/build/install-common-modules.sh
-      - run: VERSION=8.11.0 TESTKIT_VERSION=8.1.20 bin/build/run-jira-its.sh
+      - run: VERSION=8.12.2 TESTKIT_VERSION=8.1.20 bin/build/run-jira-its.sh
       - uses: actions/upload-artifact@v2
         if: failure()
         with:
-          name: webdriver-screenshots-jira-8.11.0-java-${{ matrix.java-version }}
+          name: webdriver-screenshots-jira-8.12.2-java-${{ matrix.java-version }}
           path: jira-slack-server-integration/jira-slack-server-integration-plugin/target/webdriverTests/**
 
   integration-tests-confluence-6:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ or [Bitbucket](https://marketplace.atlassian.com/apps/1220729/bitbucket-server-f
 Links to the official documentation are specified on Marketplace pages.
 
 Supported products (on 22 Jul, 2020). See [EOL policy](https://confluence.atlassian.com/support/atlassian-support-end-of-life-policy-201851003.html).
-* Jira: 7.12.3 (EOL 27 Aug, 2020) JDK 8 - 8.11.0 (EOL 15 Jul 2022) on JDK 8, 11.
+* Jira: 7.12.3 (EOL 27 Aug, 2020) JDK 8 - 8.12.2 (EOL 26 Aug 2022) on JDK 8, 11.
 * Confluence: 6.11.2 (EOL Aug 14, 2020) JDK 8 - 7.6.1 (EOL 30 Jun 2020) JDK 8, 11.
 * Bitbucket: 6.7.1 (EOL 1 Oct, 2021) on JDK 8, 11 - 7.4.0 (EOL 9 Jul, 2022) on JDK 8, 11.
 


### PR DESCRIPTION
With this change Jira 8.12.2 will be used in integration tests by default.