### PR TITLE
#49: Bumped latest supported Bitbucket version to 7.6.0

### DIFF
--- a/.github/workflows/all-tests.yml
+++ b/.github/workflows/all-tests.yml
@@ -192,7 +192,7 @@ jobs:
     strategy:
       matrix:
         java-version: [8, 11]
-        bitbucket-version: [6.7.1, 7.4.0]
+        bitbucket-version: [6.7.1, 7.6.0]
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Links to the official documentation are specified on Marketplace pages.
 Supported products (on 22 Jul, 2020). See [EOL policy](https://confluence.atlassian.com/support/atlassian-support-end-of-life-policy-201851003.html).
 * Jira: 7.12.3 (EOL 27 Aug, 2020) JDK 8 - 8.11.0 (EOL 15 Jul 2022) on JDK 8, 11.
 * Confluence: 6.11.2 (EOL Aug 14, 2020) JDK 8 - 7.6.1 (EOL 30 Jun 2020) JDK 8, 11.
-* Bitbucket: 6.7.1 (EOL 1 Oct, 2021) on JDK 8, 11 - 7.4.0 (EOL 9 Jul, 2022) on JDK 8, 11.
+* Bitbucket: 6.7.1 (EOL 1 Oct, 2021) on JDK 8, 11 - 7.6.0 (EOL 15 Sep, 2022) on JDK 8, 11.
 
 # Installation
 


### PR DESCRIPTION
Adding Bitbucket 7.6.0 as the latest supported version to test suite and README.