### PR TITLE
#49: Bumped latest supported Confluence version to 7.8.0

### DIFF
--- a/.github/workflows/all-tests.yml
+++ b/.github/workflows/all-tests.yml
@@ -148,7 +148,7 @@ jobs:
           path: confluence-slack-server-integration-plugin/target/webdriverTests/**
 
   integration-tests-confluence-7:
-    name: Integration Tests - Confluence 7.6.1
+    name: Integration Tests - Confluence 7.8.0
     runs-on: ubuntu-latest
     timeout-minutes: 15
     if: github.event.inputs.jobs == '' || contains(github.event.inputs.jobs, 'integration-tests-confluence-6')
@@ -174,13 +174,13 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: ~/.m2/repository/com/atlassian/confluence
-          key: maven-integration-confluence-7.6.1
+          key: maven-integration-confluence-7.8.0
       - run: bin/build/install-common-modules.sh
-      - run: VERSION=7.6.1 bin/build/run-confluence-its.sh
+      - run: VERSION=7.8.0 bin/build/run-confluence-its.sh
       - uses: actions/upload-artifact@v2
         if: failure()
         with:
-          name: webdriver-screenshots-confluence-7.6.1-java-${{ matrix.java-version }}
+          name: webdriver-screenshots-confluence-7.8.0-java-${{ matrix.java-version }}
           path: confluence-slack-server-integration-plugin/target/webdriverTests/**
 
   integration-tests-bitbucket:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Links to the official documentation are specified on Marketplace pages.
 
 Supported products (on 22 Jul, 2020). See [EOL policy](https://confluence.atlassian.com/support/atlassian-support-end-of-life-policy-201851003.html).
 * Jira: 7.12.3 (EOL 27 Aug, 2020) JDK 8 - 8.12.2 (EOL 26 Aug 2022) on JDK 8, 11.
-* Confluence: 6.11.2 (EOL Aug 14, 2020) JDK 8 - 7.6.1 (EOL 30 Jun 2020) JDK 8, 11.
+* Confluence: 6.11.2 (EOL Aug 14, 2020) JDK 8 - 7.8.0 (EOL 29 Sep 2022) JDK 8, 11.
 * Bitbucket: 6.7.1 (EOL 1 Oct, 2021) on JDK 8, 11 - 7.6.0 (EOL 15 Sep, 2022) on JDK 8, 11.
 
 # Installation


### PR DESCRIPTION
Adding Confluence 7.8.0 as the latest supported version to test suite and README.