### PR TITLE
#24: Fix missing transition notifications

### DIFF
--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/manager/impl/DefaultDedicatedChannelManager.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/manager/impl/DefaultDedicatedChannelManager.java
@@ -95,9 +95,8 @@ public class DefaultDedicatedChannelManager extends AutoSubscribingEventListener
         }
 
         // restricted comments notification should not be sent to dedicated channels
-        final IssueEvent issueEvent = event.getIssueEvent();
-        final Comment comment = issueEvent.getComment();
-        final Issue issue = issueEvent.getIssue();
+        final Comment comment = event.getComment().orElse(null);
+        final Issue issue = event.getIssue();
         final boolean isRestrictedComment = eventMatcher == EventMatcherType.ISSUE_COMMENTED && CommentUtil.isRestricted(comment);
         if (isRestrictedComment && !projectConfigurationManager.shouldSendRestrictedCommentsToDedicatedChannels(issue.getProjectObject())) {
             return Optional.empty();

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/manager/impl/DefaultDedicatedChannelManager.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/manager/impl/DefaultDedicatedChannelManager.java
@@ -2,7 +2,6 @@ package com.atlassian.jira.plugins.slack.manager.impl;
 
 import com.atlassian.event.api.EventListener;
 import com.atlassian.event.api.EventPublisher;
-import com.atlassian.jira.event.issue.IssueEvent;
 import com.atlassian.jira.issue.Issue;
 import com.atlassian.jira.issue.comments.Comment;
 import com.atlassian.jira.permission.ProjectPermissions;

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/model/EventMatcherType.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/model/EventMatcherType.java
@@ -40,14 +40,7 @@ public enum EventMatcherType {
      * We need to add multiple events to the issue transitioned cause Jira classic workflow send specific event types
      * for each transition.
      */
-    ISSUE_TRANSITIONED("MATCHER:ISSUE_TRANSITIONED",
-            new WorkflowStatusMatcher(),
-            EventType.ISSUE_GENERICEVENT_ID,
-            EventType.ISSUE_CLOSED_ID,
-            EventType.ISSUE_REOPENED_ID,
-            EventType.ISSUE_RESOLVED_ID,
-            EventType.ISSUE_WORKSTARTED_ID,
-            EventType.ISSUE_WORKSTOPPED_ID) {
+    ISSUE_TRANSITIONED("MATCHER:ISSUE_TRANSITIONED", new WorkflowStatusMatcher()) {
         @Override
         public <T, E extends Throwable> T accept(Visitor<T, E> visitor) throws E {
             return visitor.visitTransitioned();

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/model/event/JiraIssueEvent.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/model/event/JiraIssueEvent.java
@@ -1,6 +1,5 @@
 package com.atlassian.jira.plugins.slack.model.event;
 
-import com.atlassian.jira.event.issue.IssueEvent;
 import com.atlassian.jira.issue.Issue;
 import com.atlassian.jira.issue.comments.Comment;
 import com.atlassian.jira.plugins.slack.model.EventMatcherType;

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/model/event/JiraIssueEvent.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/model/event/JiraIssueEvent.java
@@ -1,18 +1,22 @@
 package com.atlassian.jira.plugins.slack.model.event;
 
 import com.atlassian.jira.event.issue.IssueEvent;
+import com.atlassian.jira.issue.Issue;
+import com.atlassian.jira.issue.comments.Comment;
 import com.atlassian.jira.plugins.slack.model.EventMatcherType;
+import com.atlassian.jira.plugins.slack.util.changelog.ChangeLogItem;
+import com.atlassian.jira.user.ApplicationUser;
+
+import java.util.List;
+import java.util.Optional;
 
 /**
  * This interface contains information about an issue event sent from Jira.
  */
 public interface JiraIssueEvent extends PluginEvent {
-    /**
-     * Returns the issue event from jira
-     *
-     * @return the issue event
-     */
-    IssueEvent getIssueEvent();
-
     EventMatcherType getEventMatcher();
+    Optional<ApplicationUser> getEventAuthor();
+    Issue getIssue();
+    Optional<Comment> getComment();
+    List<ChangeLogItem> getChangeLog();
 }

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/service/issuefilter/IssueFilter.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/service/issuefilter/IssueFilter.java
@@ -1,6 +1,5 @@
 package com.atlassian.jira.plugins.slack.service.issuefilter;
 
-import com.atlassian.jira.event.issue.IssueEvent;
 import com.atlassian.jira.plugins.slack.model.EventFilterType;
 import com.atlassian.jira.plugins.slack.model.event.JiraIssueEvent;
 

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/service/issuefilter/IssueFilter.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/service/issuefilter/IssueFilter.java
@@ -2,6 +2,7 @@ package com.atlassian.jira.plugins.slack.service.issuefilter;
 
 import com.atlassian.jira.event.issue.IssueEvent;
 import com.atlassian.jira.plugins.slack.model.EventFilterType;
+import com.atlassian.jira.plugins.slack.model.event.JiraIssueEvent;
 
 import javax.validation.constraints.NotNull;
 
@@ -18,7 +19,7 @@ public interface IssueFilter {
      * @param value the value to match
      * @return true if it applies a filter , false if not
      */
-    boolean apply(final IssueEvent event, @NotNull final String value);
+    boolean apply(final JiraIssueEvent event, @NotNull final String value);
 
     /**
      * Returns the map of the filter type

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/service/issuefilter/IssueFilterService.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/service/issuefilter/IssueFilterService.java
@@ -1,7 +1,7 @@
 package com.atlassian.jira.plugins.slack.service.issuefilter;
 
-import com.atlassian.jira.event.issue.IssueEvent;
 import com.atlassian.jira.plugins.slack.model.ProjectConfiguration;
+import com.atlassian.jira.plugins.slack.model.event.JiraIssueEvent;
 
 import java.util.Collection;
 
@@ -17,5 +17,5 @@ public interface IssueFilterService {
      * @param configurations the filters we are going to run
      * @return true if the issue applies, false if not
      */
-    boolean apply(final IssueEvent event, final Collection<ProjectConfiguration> configurations);
+    boolean apply(final JiraIssueEvent event, final Collection<ProjectConfiguration> configurations);
 }

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/service/issuefilter/impl/AbstractSimpleIssueFilter.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/service/issuefilter/impl/AbstractSimpleIssueFilter.java
@@ -1,7 +1,7 @@
 package com.atlassian.jira.plugins.slack.service.issuefilter.impl;
 
-import com.atlassian.jira.event.issue.IssueEvent;
 import com.atlassian.jira.plugins.slack.model.dto.MultipleValue;
+import com.atlassian.jira.plugins.slack.model.event.JiraIssueEvent;
 import com.atlassian.jira.plugins.slack.service.issuefilter.IssueFilter;
 
 import javax.validation.constraints.NotNull;
@@ -11,11 +11,11 @@ import javax.validation.constraints.NotNull;
  */
 public abstract class AbstractSimpleIssueFilter implements IssueFilter {
     @Override
-    public boolean apply(IssueEvent event, @NotNull String value) {
+    public boolean apply(JiraIssueEvent event, @NotNull String value) {
         final String issueValue = getIssueValue(event);
         return new MultipleValue(value).apply(issueValue);
     }
 
 
-    public abstract String getIssueValue(@NotNull final IssueEvent event);
+    public abstract String getIssueValue(@NotNull final JiraIssueEvent event);
 }

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/service/issuefilter/impl/DefaultIssueFilterService.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/service/issuefilter/impl/DefaultIssueFilterService.java
@@ -3,6 +3,7 @@ package com.atlassian.jira.plugins.slack.service.issuefilter.impl;
 import com.atlassian.jira.event.issue.IssueEvent;
 import com.atlassian.jira.plugins.slack.model.EventFilterType;
 import com.atlassian.jira.plugins.slack.model.ProjectConfiguration;
+import com.atlassian.jira.plugins.slack.model.event.JiraIssueEvent;
 import com.atlassian.jira.plugins.slack.service.issuefilter.IssueFilter;
 import com.atlassian.jira.plugins.slack.service.issuefilter.IssueFilterService;
 import com.google.common.collect.ImmutableList;
@@ -37,7 +38,7 @@ public class DefaultIssueFilterService implements IssueFilterService {
      * Returns true if all filters match.
      */
     @Override
-    public boolean apply(final IssueEvent event, Collection<ProjectConfiguration> configurations) {
+    public boolean apply(final JiraIssueEvent event, Collection<ProjectConfiguration> configurations) {
         final List<IssueFilterConfiguration> filtersToRun = getFiltersToRunFor(configurations);
         return filtersToRun.stream().allMatch(issueFilter ->
                 issueFilter != null && issueFilter.getFilter().apply(event, issueFilter.getConfiguration().getValue()));

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/service/issuefilter/impl/DefaultIssueFilterService.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/service/issuefilter/impl/DefaultIssueFilterService.java
@@ -1,6 +1,5 @@
 package com.atlassian.jira.plugins.slack.service.issuefilter.impl;
 
-import com.atlassian.jira.event.issue.IssueEvent;
 import com.atlassian.jira.plugins.slack.model.EventFilterType;
 import com.atlassian.jira.plugins.slack.model.ProjectConfiguration;
 import com.atlassian.jira.plugins.slack.model.event.JiraIssueEvent;

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/service/issuefilter/impl/IssuePriorityFilter.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/service/issuefilter/impl/IssuePriorityFilter.java
@@ -1,7 +1,7 @@
 package com.atlassian.jira.plugins.slack.service.issuefilter.impl;
 
-import com.atlassian.jira.event.issue.IssueEvent;
 import com.atlassian.jira.plugins.slack.model.EventFilterType;
+import com.atlassian.jira.plugins.slack.model.event.JiraIssueEvent;
 import org.springframework.stereotype.Service;
 
 import javax.validation.constraints.NotNull;
@@ -12,7 +12,7 @@ import javax.validation.constraints.NotNull;
 @Service
 public class IssuePriorityFilter extends AbstractSimpleIssueFilter {
     @Override
-    public String getIssueValue(@NotNull final IssueEvent event) {
+    public String getIssueValue(@NotNull final JiraIssueEvent event) {
         if (event.getIssue() == null || event.getIssue().getPriority() == null) {
             return null;
         }

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/service/issuefilter/impl/IssueTypeFilter.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/service/issuefilter/impl/IssueTypeFilter.java
@@ -1,7 +1,7 @@
 package com.atlassian.jira.plugins.slack.service.issuefilter.impl;
 
-import com.atlassian.jira.event.issue.IssueEvent;
 import com.atlassian.jira.plugins.slack.model.EventFilterType;
+import com.atlassian.jira.plugins.slack.model.event.JiraIssueEvent;
 import org.springframework.stereotype.Service;
 
 import javax.validation.constraints.NotNull;
@@ -18,7 +18,7 @@ public class IssueTypeFilter extends AbstractSimpleIssueFilter {
     }
 
     @Override
-    public String getIssueValue(@NotNull final IssueEvent event) {
+    public String getIssueValue(@NotNull final JiraIssueEvent event) {
         return event.getIssue().getIssueTypeId();
     }
 

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/service/issuefilter/impl/JqlIssueFilter.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/service/issuefilter/impl/JqlIssueFilter.java
@@ -1,12 +1,12 @@
 package com.atlassian.jira.plugins.slack.service.issuefilter.impl;
 
 import com.atlassian.jira.bc.issue.search.SearchService;
-import com.atlassian.jira.event.issue.IssueEvent;
 import com.atlassian.jira.issue.Issue;
 import com.atlassian.jira.issue.search.SearchException;
 import com.atlassian.jira.jql.builder.JqlQueryBuilder;
 import com.atlassian.jira.plugins.slack.bridge.jql.JqlSearcher;
 import com.atlassian.jira.plugins.slack.model.EventFilterType;
+import com.atlassian.jira.plugins.slack.model.event.JiraIssueEvent;
 import com.atlassian.jira.plugins.slack.service.issuefilter.IssueFilter;
 import com.atlassian.jira.user.ApplicationUser;
 import com.atlassian.query.Query;
@@ -39,9 +39,9 @@ public class JqlIssueFilter implements IssueFilter {
     }
 
     @Override
-    public boolean apply(final IssueEvent event, final @NotNull String value) {
+    public boolean apply(final JiraIssueEvent event, final @NotNull String value) {
         try {
-            return matchesJql(value, event.getIssue(), Optional.ofNullable(event.getUser()));
+            return matchesJql(value, event.getIssue(), event.getEventAuthor());
         } catch (SearchException e) {
             log.warn(" Search exception trying to match jql [{}] over issue []", value, event.getIssue().getId());
         }

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/service/listener/IssueEventToEventMatcherTypeConverter.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/service/listener/IssueEventToEventMatcherTypeConverter.java
@@ -1,5 +1,6 @@
 package com.atlassian.jira.plugins.slack.service.listener;
 
+import com.atlassian.jira.event.issue.IssueChangedEvent;
 import com.atlassian.jira.event.issue.IssueEvent;
 import com.atlassian.jira.plugins.slack.model.EventMatcherType;
 
@@ -14,4 +15,6 @@ public interface IssueEventToEventMatcherTypeConverter {
      * on the updated fields
      */
     Collection<EventMatcherType> match(IssueEvent issueEvent);
+
+    Collection<EventMatcherType> match(IssueChangedEvent issueChangedEvent);
 }

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/service/notification/PersonalNotificationManager.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/service/notification/PersonalNotificationManager.java
@@ -1,6 +1,5 @@
 package com.atlassian.jira.plugins.slack.service.notification;
 
-import com.atlassian.jira.event.issue.IssueEvent;
 import com.atlassian.jira.issue.Issue;
 import com.atlassian.jira.issue.comments.Comment;
 import com.atlassian.jira.issue.comments.CommentManager;

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/service/notification/PersonalNotificationManager.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/service/notification/PersonalNotificationManager.java
@@ -46,11 +46,10 @@ public class PersonalNotificationManager {
             return Collections.emptyList();
         }
 
-        final IssueEvent issueEvent = event.getIssueEvent();
-        final Issue issue = issueEvent.getIssue();
-        final ApplicationUser actor = issueEvent.getUser();
+        final Issue issue = event.getIssue();
+        final ApplicationUser actor = event.getEventAuthor().orElse(null);
         final EventMatcherType eventMatcher = event.getEventMatcher();
-        final Comment comment = issueEvent.getComment();
+        final Comment comment = event.getComment().orElse(null);
         final boolean isRestrictedCommentAdded = eventMatcher == EventMatcherType.ISSUE_COMMENTED
                 && CommentUtil.isRestricted(comment);
 

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/service/notification/impl/DefaultIssueEventProcessorService.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/service/notification/impl/DefaultIssueEventProcessorService.java
@@ -69,10 +69,9 @@ public class DefaultIssueEventProcessorService implements IssueEventProcessorSer
             return Collections.emptyList();
         }
 
-        final IssueEvent issueEvent = event.getIssueEvent();
-        final Project project = issueEvent.getProject();
-        final Issue issue = issueEvent.getIssue();
-        final Comment comment = issueEvent.getComment();
+        final Issue issue = event.getIssue();
+        final Project project = issue.getProjectObject();
+        final Comment comment = event.getComment().orElse(null);
         final List<ProjectConfiguration> configurations = getConfigurationFor(project.getId(), issue, comment, eventMatcher);
 
         log.debug("Finding Configurations for event [{}] : {}", eventMatcher.name(), size(configurations));
@@ -84,7 +83,7 @@ public class DefaultIssueEventProcessorService implements IssueEventProcessorSer
                         projectConfiguration.getConfigurationGroupId()))
                 .filter(selector -> {
                     final List<ProjectConfiguration> filterConfigs = getConfigurationFiltersFor(selector);
-                    return CollectionUtils.isEmpty(filterConfigs) || filterService.apply(issueEvent, filterConfigs);
+                    return CollectionUtils.isEmpty(filterConfigs) || filterService.apply(event, filterConfigs);
                 })
                 .flatMap(selector -> getNotificationInfos(selector).stream())
                 .collect(Collectors.toList());

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/service/notification/impl/DefaultIssueEventProcessorService.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/service/notification/impl/DefaultIssueEventProcessorService.java
@@ -1,6 +1,5 @@
 package com.atlassian.jira.plugins.slack.service.notification.impl;
 
-import com.atlassian.jira.event.issue.IssueEvent;
 import com.atlassian.jira.issue.Issue;
 import com.atlassian.jira.issue.comments.Comment;
 import com.atlassian.jira.plugins.slack.dao.ConfigurationDAO;

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/util/changelog/ChangeLogExtractor.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/util/changelog/ChangeLogExtractor.java
@@ -68,7 +68,7 @@ public class ChangeLogExtractor {
                         if (maxValueLength != -1) {
                             newText = StringUtils.abbreviate(newText, maxValueLength);
                         }
-                        changeLogItems.add(new ChangeLogItem(field, field, newText, newValue, oldText, oldValue));
+                        changeLogItems.add(new ChangeLogItem(field, newText, newValue, oldText, oldValue));
                     }
                 }
 

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/util/changelog/ChangeLogItem.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/util/changelog/ChangeLogItem.java
@@ -1,43 +1,21 @@
 package com.atlassian.jira.plugins.slack.util.changelog;
 
+import lombok.Value;
+import org.apache.commons.lang3.StringUtils;
+
+@Value
 public class ChangeLogItem {
-    private final String field;
-    private final String fieldName;
-    private final String newText;
-    private final String newValue;
-    private final String oldText;
-    private final String oldValue;
+    String field;
+    String newText;
+    String newValue;
+    String oldText;
+    String oldValue;
 
-    ChangeLogItem(String field, String fieldName, String newText, String newValue, String oldText, String oldValue) {
-        this.field = field;
-        this.fieldName = fieldName;
-        this.newText = newText;
-        this.newValue = newValue;
-        this.oldText = oldText;
-        this.oldValue = oldValue;
+    public String getNewTextTruncated(final int maxLength) {
+        return StringUtils.abbreviate(newText, maxLength);
     }
 
-    public String getField() {
-        return field;
-    }
-
-    public String getFieldName() {
-        return fieldName;
-    }
-
-    public String getNewText() {
-        return newText;
-    }
-
-    public String getNewValue() {
-        return newValue;
-    }
-
-    public String getOldText() {
-        return oldText;
-    }
-
-    public String getOldValue() {
-        return oldValue;
+    public String getOldTextTruncated(final int maxLength) {
+        return StringUtils.abbreviate(oldText, maxLength);
     }
 }

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/test/java/com/atlassian/jira/plugins/slack/manager/impl/DefaultDedicatedChannelManagerTest.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/test/java/com/atlassian/jira/plugins/slack/manager/impl/DefaultDedicatedChannelManagerTest.java
@@ -113,7 +113,7 @@ public class DefaultDedicatedChannelManagerTest {
     public void getNotificationsFor() {
         IssueEvent issueEvent = new IssueEvent(issue, Collections.emptyMap(), null, 1L);
         when(jiraIssueEvent.getEventMatcher()).thenReturn(EventMatcherType.ISSUE_COMMENTED);
-        when(jiraIssueEvent.getIssueEvent()).thenReturn(issueEvent);
+        when(jiraIssueEvent.getIssue()).thenReturn(issue);
         when(issue.getId()).thenReturn(7L);
         when(dedicatedChannelDAO.getDedicatedChannel(7L)).thenReturn(Optional.of(dedicatedChannel));
         when(dedicatedChannel.getTeamId()).thenReturn("T");
@@ -144,7 +144,7 @@ public class DefaultDedicatedChannelManagerTest {
         Comment comment = mock(Comment.class);
         Project project = mock(Project.class);
         when(jiraIssueEvent.getEventMatcher()).thenReturn(EventMatcherType.ISSUE_COMMENTED);
-        when(jiraIssueEvent.getIssueEvent()).thenReturn(issueEvent);
+        when(jiraIssueEvent.getIssue()).thenReturn(issue);
         when(issueEvent.getIssue()).thenReturn(issue);
         when(issueEvent.getComment()).thenReturn(comment);
         when(issue.getProjectObject()).thenReturn(project);
@@ -161,7 +161,7 @@ public class DefaultDedicatedChannelManagerTest {
         Comment comment = mock(Comment.class);
         Project project = mock(Project.class);
         when(jiraIssueEvent.getEventMatcher()).thenReturn(EventMatcherType.ISSUE_COMMENTED);
-        when(jiraIssueEvent.getIssueEvent()).thenReturn(issueEvent);
+        when(jiraIssueEvent.getIssue()).thenReturn(issue);
         when(issueEvent.getIssue()).thenReturn(issue);
         when(issueEvent.getComment()).thenReturn(comment);
         when(issue.getProjectObject()).thenReturn(project);

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/test/java/com/atlassian/jira/plugins/slack/service/issuefilter/impl/DefaultIssueFilterServiceTest.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/test/java/com/atlassian/jira/plugins/slack/service/issuefilter/impl/DefaultIssueFilterServiceTest.java
@@ -3,7 +3,9 @@ package com.atlassian.jira.plugins.slack.service.issuefilter.impl;
 import com.atlassian.jira.event.issue.IssueEvent;
 import com.atlassian.jira.issue.Issue;
 import com.atlassian.jira.plugins.slack.model.EventFilterType;
+import com.atlassian.jira.plugins.slack.model.EventMatcherType;
 import com.atlassian.jira.plugins.slack.model.ProjectConfiguration;
+import com.atlassian.jira.plugins.slack.model.event.DefaultJiraIssueEvent;
 import com.atlassian.jira.plugins.slack.service.issuefilter.IssueFilter;
 import org.junit.Rule;
 import org.junit.Test;
@@ -15,6 +17,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import static java.util.Collections.emptyList;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
@@ -47,12 +50,13 @@ public class DefaultIssueFilterServiceTest {
         when(projectConfiguration2.getValue()).thenReturn("V2");
 
         IssueEvent issueEvent = new IssueEvent(issue, Collections.emptyMap(), null, 0L);
+        DefaultJiraIssueEvent jiraIssueEvent = DefaultJiraIssueEvent.of(EventMatcherType.ISSUE_CREATED, issueEvent, emptyList());
 
-        when(issueFilter1.apply(issueEvent, "V1")).thenReturn(true);
-        when(issueFilter2.apply(issueEvent, "V2")).thenReturn(true);
+        when(issueFilter1.apply(jiraIssueEvent, "V1")).thenReturn(true);
+        when(issueFilter2.apply(jiraIssueEvent, "V2")).thenReturn(true);
 
         DefaultIssueFilterService target = new DefaultIssueFilterService(filters);
-        boolean result = target.apply(issueEvent, configs);
+        boolean result = target.apply(jiraIssueEvent, configs);
 
         assertThat(result, is(true));
     }
@@ -70,12 +74,13 @@ public class DefaultIssueFilterServiceTest {
         when(projectConfiguration2.getValue()).thenReturn("V2");
 
         IssueEvent issueEvent = new IssueEvent(issue, Collections.emptyMap(), null, 0L);
+        DefaultJiraIssueEvent jiraIssueEvent = DefaultJiraIssueEvent.of(EventMatcherType.ISSUE_CREATED, issueEvent, emptyList());
 
-        when(issueFilter1.apply(issueEvent, "V1")).thenReturn(true);
-        when(issueFilter2.apply(issueEvent, "V2")).thenReturn(false);
+        when(issueFilter1.apply(jiraIssueEvent, "V1")).thenReturn(true);
+        when(issueFilter2.apply(jiraIssueEvent, "V2")).thenReturn(false);
 
         DefaultIssueFilterService target = new DefaultIssueFilterService(filters);
-        boolean result = target.apply(issueEvent, configs);
+        boolean result = target.apply(jiraIssueEvent, configs);
 
         assertThat(result, is(false));
     }

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/test/java/com/atlassian/jira/plugins/slack/service/issuefilter/impl/IssuePriorityFilterTest.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/test/java/com/atlassian/jira/plugins/slack/service/issuefilter/impl/IssuePriorityFilterTest.java
@@ -4,6 +4,8 @@ import com.atlassian.jira.event.issue.IssueEvent;
 import com.atlassian.jira.issue.Issue;
 import com.atlassian.jira.issue.priority.Priority;
 import com.atlassian.jira.plugins.slack.model.EventFilterType;
+import com.atlassian.jira.plugins.slack.model.EventMatcherType;
+import com.atlassian.jira.plugins.slack.model.event.DefaultJiraIssueEvent;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.InjectMocks;
@@ -13,6 +15,7 @@ import org.mockito.junit.MockitoRule;
 
 import java.util.Collections;
 
+import static java.util.Collections.emptyList;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
@@ -32,42 +35,45 @@ public class IssuePriorityFilterTest {
     @Test
     public void apply() {
         IssueEvent issueEvent = new IssueEvent(issue, Collections.emptyMap(), null, 0L);
+        DefaultJiraIssueEvent jiraIssueEvent = DefaultJiraIssueEvent.of(EventMatcherType.ISSUE_CREATED, issueEvent, emptyList());
         when(issue.getPriority()).thenReturn(priority);
         when(priority.getId()).thenReturn("M");
 
-        assertThat(target.apply(issueEvent, "ALL"), is(true));
-        assertThat(target.apply(issueEvent, ""), is(true));
-        assertThat(target.apply(issueEvent, null), is(true));
-        assertThat(target.apply(issueEvent, "M"), is(true));
-        assertThat(target.apply(issueEvent, "H,M"), is(true));
-        assertThat(target.apply(issueEvent, "H"), is(false));
+        assertThat(target.apply(jiraIssueEvent, "ALL"), is(true));
+        assertThat(target.apply(jiraIssueEvent, ""), is(true));
+        assertThat(target.apply(jiraIssueEvent, null), is(true));
+        assertThat(target.apply(jiraIssueEvent, "M"), is(true));
+        assertThat(target.apply(jiraIssueEvent, "H,M"), is(true));
+        assertThat(target.apply(jiraIssueEvent, "H"), is(false));
     }
 
     @Test
     public void apply_shouldReturnFalseWhenValueIsEmpty() {
         IssueEvent issueEvent = new IssueEvent(issue, Collections.emptyMap(), null, 0L);
+        DefaultJiraIssueEvent jiraIssueEvent = DefaultJiraIssueEvent.of(EventMatcherType.ISSUE_CREATED, issueEvent, emptyList());
         when(issue.getPriority()).thenReturn(priority);
         when(priority.getId()).thenReturn("");
 
-        assertThat(target.apply(issueEvent, "ALL"), is(true));
-        assertThat(target.apply(issueEvent, ""), is(true));
-        assertThat(target.apply(issueEvent, null), is(true));
-        assertThat(target.apply(issueEvent, "M"), is(false));
-        assertThat(target.apply(issueEvent, "H,M"), is(false));
-        assertThat(target.apply(issueEvent, "H"), is(false));
+        assertThat(target.apply(jiraIssueEvent, "ALL"), is(true));
+        assertThat(target.apply(jiraIssueEvent, ""), is(true));
+        assertThat(target.apply(jiraIssueEvent, null), is(true));
+        assertThat(target.apply(jiraIssueEvent, "M"), is(false));
+        assertThat(target.apply(jiraIssueEvent, "H,M"), is(false));
+        assertThat(target.apply(jiraIssueEvent, "H"), is(false));
     }
 
     @Test
     public void apply_shouldReturnFalseWhenPriorityIsNull() {
         IssueEvent issueEvent = new IssueEvent(issue, Collections.emptyMap(), null, 0L);
+        DefaultJiraIssueEvent jiraIssueEvent = DefaultJiraIssueEvent.of(EventMatcherType.ISSUE_CREATED, issueEvent, emptyList());
         when(issue.getPriority()).thenReturn(null);
 
-        assertThat(target.apply(issueEvent, "ALL"), is(true));
-        assertThat(target.apply(issueEvent, ""), is(true));
-        assertThat(target.apply(issueEvent, null), is(true));
-        assertThat(target.apply(issueEvent, "M"), is(false));
-        assertThat(target.apply(issueEvent, "H,M"), is(false));
-        assertThat(target.apply(issueEvent, "H"), is(false));
+        assertThat(target.apply(jiraIssueEvent, "ALL"), is(true));
+        assertThat(target.apply(jiraIssueEvent, ""), is(true));
+        assertThat(target.apply(jiraIssueEvent, null), is(true));
+        assertThat(target.apply(jiraIssueEvent, "M"), is(false));
+        assertThat(target.apply(jiraIssueEvent, "H,M"), is(false));
+        assertThat(target.apply(jiraIssueEvent, "H"), is(false));
     }
 
     @Test

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/test/java/com/atlassian/jira/plugins/slack/service/issuefilter/impl/IssueTypeFilterTest.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/test/java/com/atlassian/jira/plugins/slack/service/issuefilter/impl/IssueTypeFilterTest.java
@@ -3,6 +3,8 @@ package com.atlassian.jira.plugins.slack.service.issuefilter.impl;
 import com.atlassian.jira.event.issue.IssueEvent;
 import com.atlassian.jira.issue.Issue;
 import com.atlassian.jira.plugins.slack.model.EventFilterType;
+import com.atlassian.jira.plugins.slack.model.EventMatcherType;
+import com.atlassian.jira.plugins.slack.model.event.DefaultJiraIssueEvent;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.InjectMocks;
@@ -12,9 +14,9 @@ import org.mockito.junit.MockitoRule;
 
 import java.util.Collections;
 
+import static java.util.Collections.emptyList;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class IssueTypeFilterTest {
@@ -30,40 +32,43 @@ public class IssueTypeFilterTest {
     @Test
     public void apply_shouldReturnTrueWhenTypeMatches() {
         IssueEvent issueEvent = new IssueEvent(issue, Collections.emptyMap(), null, 0L);
+        DefaultJiraIssueEvent jiraIssueEvent = DefaultJiraIssueEvent.of(EventMatcherType.ISSUE_CREATED, issueEvent, emptyList());
         when(issue.getIssueTypeId()).thenReturn("B");
 
-        assertThat(target.apply(issueEvent, "ALL"), is(true));
-        assertThat(target.apply(issueEvent, ""), is(true));
-        assertThat(target.apply(issueEvent, null), is(true));
-        assertThat(target.apply(issueEvent, "B"), is(true));
-        assertThat(target.apply(issueEvent, "B,T"), is(true));
-        assertThat(target.apply(issueEvent, "T"), is(false));
+        assertThat(target.apply(jiraIssueEvent, "ALL"), is(true));
+        assertThat(target.apply(jiraIssueEvent, ""), is(true));
+        assertThat(target.apply(jiraIssueEvent, null), is(true));
+        assertThat(target.apply(jiraIssueEvent, "B"), is(true));
+        assertThat(target.apply(jiraIssueEvent, "B,T"), is(true));
+        assertThat(target.apply(jiraIssueEvent, "T"), is(false));
     }
 
     @Test
     public void apply_shouldReturnFalseWhenIssueTypeIdIsEmpty() {
         IssueEvent issueEvent = new IssueEvent(issue, Collections.emptyMap(), null, 0L);
+        DefaultJiraIssueEvent jiraIssueEvent = DefaultJiraIssueEvent.of(EventMatcherType.ISSUE_CREATED, issueEvent, emptyList());
         when(issue.getIssueTypeId()).thenReturn("");
 
-        assertThat(target.apply(issueEvent, "ALL"), is(true));
-        assertThat(target.apply(issueEvent, ""), is(true));
-        assertThat(target.apply(issueEvent, null), is(true));
-        assertThat(target.apply(issueEvent, "B"), is(false));
-        assertThat(target.apply(issueEvent, "B,T"), is(false));
-        assertThat(target.apply(issueEvent, "T"), is(false));
+        assertThat(target.apply(jiraIssueEvent, "ALL"), is(true));
+        assertThat(target.apply(jiraIssueEvent, ""), is(true));
+        assertThat(target.apply(jiraIssueEvent, null), is(true));
+        assertThat(target.apply(jiraIssueEvent, "B"), is(false));
+        assertThat(target.apply(jiraIssueEvent, "B,T"), is(false));
+        assertThat(target.apply(jiraIssueEvent, "T"), is(false));
     }
 
     @Test
     public void apply_shouldReturnFalseWhenIssueTypeIdIsNull() {
         IssueEvent issueEvent = new IssueEvent(issue, Collections.emptyMap(), null, 0L);
+        DefaultJiraIssueEvent jiraIssueEvent = DefaultJiraIssueEvent.of(EventMatcherType.ISSUE_CREATED, issueEvent, emptyList());
         when(issue.getIssueTypeId()).thenReturn(null);
 
-        assertThat(target.apply(issueEvent, "ALL"), is(true));
-        assertThat(target.apply(issueEvent, ""), is(true));
-        assertThat(target.apply(issueEvent, null), is(true));
-        assertThat(target.apply(issueEvent, "B"), is(false));
-        assertThat(target.apply(issueEvent, "B,T"), is(false));
-        assertThat(target.apply(issueEvent, "T"), is(false));
+        assertThat(target.apply(jiraIssueEvent, "ALL"), is(true));
+        assertThat(target.apply(jiraIssueEvent, ""), is(true));
+        assertThat(target.apply(jiraIssueEvent, null), is(true));
+        assertThat(target.apply(jiraIssueEvent, "B"), is(false));
+        assertThat(target.apply(jiraIssueEvent, "B,T"), is(false));
+        assertThat(target.apply(jiraIssueEvent, "T"), is(false));
     }
 
     @Test

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/test/java/com/atlassian/jira/plugins/slack/service/issuefilter/impl/JqlIssueFilterTest.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/test/java/com/atlassian/jira/plugins/slack/service/issuefilter/impl/JqlIssueFilterTest.java
@@ -8,6 +8,8 @@ import com.atlassian.jira.jql.builder.JqlClauseBuilder;
 import com.atlassian.jira.jql.builder.JqlQueryBuilder;
 import com.atlassian.jira.plugins.slack.bridge.jql.JqlSearcher;
 import com.atlassian.jira.plugins.slack.model.EventFilterType;
+import com.atlassian.jira.plugins.slack.model.EventMatcherType;
+import com.atlassian.jira.plugins.slack.model.event.DefaultJiraIssueEvent;
 import com.atlassian.jira.user.ApplicationUser;
 import com.atlassian.jira.util.MessageSet;
 import com.atlassian.query.Query;
@@ -26,6 +28,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import java.util.Collections;
 import java.util.Optional;
 
+import static java.util.Collections.emptyList;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
@@ -65,9 +68,10 @@ public class JqlIssueFilterTest {
     @Test
     public void apply_shouldReturnTrueWhenJqlIsEmpty() {
         IssueEvent issueEvent = new IssueEvent(issue, Collections.emptyMap(), null, 0L);
+        DefaultJiraIssueEvent jiraIssueEvent = DefaultJiraIssueEvent.of(EventMatcherType.ISSUE_CREATED, issueEvent, emptyList());
 
-        assertThat(target.apply(issueEvent, ""), is(true));
-        assertThat(target.apply(issueEvent, null), is(true));
+        assertThat(target.apply(jiraIssueEvent, ""), is(true));
+        assertThat(target.apply(jiraIssueEvent, null), is(true));
     }
 
     @Test

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/test/java/com/atlassian/jira/plugins/slack/service/listener/impl/DefaultJiraSlackEventListenerTest.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/test/java/com/atlassian/jira/plugins/slack/service/listener/impl/DefaultJiraSlackEventListenerTest.java
@@ -1,7 +1,6 @@
 package com.atlassian.jira.plugins.slack.service.listener.impl;
 
 import com.atlassian.event.api.EventPublisher;
-import com.atlassian.jira.bulkedit.operation.BulkEditTaskContext;
 import com.atlassian.jira.event.issue.DelegatingJiraIssueEvent;
 import com.atlassian.jira.event.issue.IssueEvent;
 import com.atlassian.jira.event.issue.IssueEventBundle;
@@ -20,8 +19,6 @@ import com.atlassian.jira.plugins.slack.service.task.TaskBuilder;
 import com.atlassian.jira.plugins.slack.service.task.TaskExecutorService;
 import com.atlassian.jira.plugins.slack.service.task.impl.SendNotificationTask;
 import com.atlassian.jira.plugins.slack.settings.JiraSettingsService;
-import com.atlassian.jira.task.TaskDescriptor;
-import com.atlassian.jira.task.TaskManager;
 import com.atlassian.jira.user.ApplicationUser;
 import com.atlassian.plugins.slack.analytics.AnalyticsContextProvider;
 import com.atlassian.plugins.slack.api.notification.Verbosity;
@@ -141,7 +138,8 @@ public class DefaultJiraSlackEventListenerTest {
 
         DefaultJiraIssueEvent defaultJiraIssueEvent = eventCaptor3.getValue();
         assertThat(defaultJiraIssueEvent.getEventMatcher(), sameInstance(EventMatcherType.ISSUE_UPDATED));
-        assertThat(defaultJiraIssueEvent.getIssueEvent(), sameInstance(issueEvent));
+        assertThat(defaultJiraIssueEvent.getIssue(), sameInstance(issue));
+        assertThat(defaultJiraIssueEvent.getEventAuthor().get(), sameInstance(applicationUser));
 
         assertThat(notInfoCaptor.getValue(), containsInAnyOrder(notificationInfo1, notificationInfo2));
 

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/test/java/com/atlassian/jira/plugins/slack/service/listener/impl/DefaultJiraSlackEventListenerTest.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/test/java/com/atlassian/jira/plugins/slack/service/listener/impl/DefaultJiraSlackEventListenerTest.java
@@ -140,9 +140,7 @@ public class DefaultJiraSlackEventListenerTest {
         verify(sendNotificationTask).call();
 
         DefaultJiraIssueEvent defaultJiraIssueEvent = eventCaptor3.getValue();
-        assertThat(defaultJiraIssueEvent.getActor(), sameInstance(applicationUser));
         assertThat(defaultJiraIssueEvent.getEventMatcher(), sameInstance(EventMatcherType.ISSUE_UPDATED));
-        assertThat(defaultJiraIssueEvent.getIssue(), sameInstance(issue));
         assertThat(defaultJiraIssueEvent.getIssueEvent(), sameInstance(issueEvent));
 
         assertThat(notInfoCaptor.getValue(), containsInAnyOrder(notificationInfo1, notificationInfo2));
@@ -164,7 +162,7 @@ public class DefaultJiraSlackEventListenerTest {
 
         target.issueEvent(issueEventBundle);
 
-        verify(issueEventToEventMatcherTypeConverter, never()).match(any());
+        verify(issueEventToEventMatcherTypeConverter, never()).match(any(IssueEvent.class));
         verify(taskBuilder, never()).newSendNotificationTask(any(), anyList(), any());
     }
 

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/test/java/com/atlassian/jira/plugins/slack/service/notification/impl/DefaultIssueEventProcessorServiceTest.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/test/java/com/atlassian/jira/plugins/slack/service/notification/impl/DefaultIssueEventProcessorServiceTest.java
@@ -9,6 +9,7 @@ import com.atlassian.jira.plugins.slack.manager.impl.DefaultProjectConfiguration
 import com.atlassian.jira.plugins.slack.model.EventFilterType;
 import com.atlassian.jira.plugins.slack.model.EventMatcherType;
 import com.atlassian.jira.plugins.slack.model.ProjectConfiguration;
+import com.atlassian.jira.plugins.slack.model.event.DefaultJiraIssueEvent;
 import com.atlassian.jira.plugins.slack.model.event.JiraIssueEvent;
 import com.atlassian.jira.plugins.slack.service.issuefilter.IssueFilterService;
 import com.atlassian.jira.plugins.slack.service.notification.NotificationInfo;
@@ -29,6 +30,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import static java.util.Collections.emptyList;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
@@ -76,10 +78,12 @@ public class DefaultIssueEventProcessorServiceTest {
     @Test
     public void getNotificationsFor_shouldReturnNotifications_whenIssueIsCreated() {
         IssueEvent issueEvent = new IssueEvent(issue, Collections.emptyMap(), null, 1L);
+        DefaultJiraIssueEvent jiraIssueEvent = DefaultJiraIssueEvent.of(EventMatcherType.ISSUE_CREATED, issueEvent, emptyList());
+
         when(issue.getProjectObject()).thenReturn(project);
         when(project.getId()).thenReturn(7L);
         when(event.getEventMatcher()).thenReturn(EventMatcherType.ISSUE_CREATED);
-        when(event.getIssueEvent()).thenReturn(issueEvent);
+        when(event.getIssue()).thenReturn(issue);
         when(configurationDAO.findByProjectId(7L)).thenReturn(Arrays.asList(projectConfiguration1,
                 projectConfiguration2, projectConfiguration3, projectConfiguration4));
         when(projectConfiguration1.getConfigurationGroupId()).thenReturn("G");
@@ -102,7 +106,7 @@ public class DefaultIssueEventProcessorServiceTest {
                 .thenReturn(Arrays.asList(projectConfiguration1, projectConfiguration2));
         when(configurationDAO.findByProjectConfigurationGroupId(7L, "G2"))
                 .thenReturn(Arrays.asList(projectConfiguration3, projectConfiguration4));
-        when(filterService.apply(issueEvent, Collections.singletonList(projectConfiguration4))).thenReturn(true);
+        when(filterService.apply(jiraIssueEvent, Collections.singletonList(projectConfiguration4))).thenReturn(true);
         when(projectConfigurationManager.getOwner(projectConfiguration1)).thenReturn(Optional.of("O1"));
         when(projectConfigurationManager.getOwner(projectConfiguration3)).thenReturn(Optional.of("O2"));
         when(projectConfigurationManager.getVerbosity(projectConfiguration1)).thenReturn(Optional.of(Verbosity.BASIC));
@@ -133,7 +137,7 @@ public class DefaultIssueEventProcessorServiceTest {
         when(project.getId()).thenReturn(projectId);
         when(comment.getGroupLevel()).thenReturn("someGroupLevel");
         when(event.getEventMatcher()).thenReturn(EventMatcherType.ISSUE_COMMENTED);
-        when(event.getIssueEvent()).thenReturn(issueEvent);
+        when(event.getIssue()).thenReturn(issue);
         when(configurationDAO.findByProjectId(projectId)).thenReturn(Arrays.asList(projectConfiguration1,
                 projectConfiguration2));
         when(projectConfiguration1.getConfigurationGroupId()).thenReturn(groupId);

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/test/java/com/atlassian/jira/plugins/slack/service/notification/impl/JiraIssueEventRendererTest.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/test/java/com/atlassian/jira/plugins/slack/service/notification/impl/JiraIssueEventRendererTest.java
@@ -122,7 +122,6 @@ public class JiraIssueEventRendererTest {
         when(jiraIssueEvent.getEventMatcher()).thenReturn(EventMatcherType.ISSUE_UPDATED);
         when(changeLogExtractor.getChanges(ArgumentMatchers.any(), eq(1000))).thenReturn(Collections.singletonList(changeLogItem));
         when(changeLogItem.getNewText()).thenReturn("N");
-        when(changeLogItem.getFieldName()).thenReturn("F");
         when(changeLogItem.getField()).thenReturn("F");
 
         SlackNotification notif = testRender(Verbosity.EXTENDED);
@@ -307,7 +306,7 @@ public class JiraIssueEventRendererTest {
 
     private SlackNotification testRender(final Verbosity verbosity) {
         IssueEvent issueEvent = new IssueEvent(issue, applicationUser, comment, null, null, Collections.emptyMap(), 1L);
-        when(jiraIssueEvent.getIssueEvent()).thenReturn(issueEvent);
+        when(jiraIssueEvent.getIssue()).thenReturn(issue);
         when(notificationInfo.getLink()).thenReturn(link);
         when(notificationInfo.getChannelId()).thenReturn("C");
         when(notificationInfo.getResponseUrl()).thenReturn("url");


### PR DESCRIPTION
In this PR I have made issue transition notifications sent on `IssueChangedEvent`'s, rather than on `IssueEvent`'s. `IssueEvent` is still responsible for sending other notifications. After this migration all transition events should be detected correctly and related Slack notifications should be sent even for custom issue statuses and custom events.