### PR TITLE
Made Jupiter running JUnit tests again and fixed all failed tests

### DIFF
--- a/bitbucket-slack-server-integration-plugin/pom.xml
+++ b/bitbucket-slack-server-integration-plugin/pom.xml
@@ -33,7 +33,7 @@
         <!-- dependency versions -->
         <atlassian.spring.scanner.version>2.1.7</atlassian.spring.scanner.version>
         <jslack.version>1.5.6</jslack.version>
-        <junit.jupiter.version>5.5.1</junit.jupiter.version>
+        <junit.jupiter.version>5.7.1</junit.jupiter.version>
         <mockito-core.version>2.25.0</mockito-core.version>
         <atlassian.selenium.version>3.0.0</atlassian.selenium.version>
         <atlassian-json-api.version>0.9</atlassian-json-api.version>

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/manager/impl/DefaultProjectConfigurationManager.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/manager/impl/DefaultProjectConfigurationManager.java
@@ -258,6 +258,9 @@ public class DefaultProjectConfigurationManager implements ProjectConfigurationM
                 .stream()
                 .filter(config -> CONFIGURATION_OWNER.equals(config.getName()))
                 .map(ProjectConfiguration::getValue)
+                // users report that sometimes project configurations don't have an owner; it caused an exception here
+                // using a null check here leads to an empty Optional being returned, that allows to handle that case gracefully
+                .filter(Objects::nonNull)
                 .findAny();
     }
 

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/model/EventMatcherType.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/model/EventMatcherType.java
@@ -36,10 +36,6 @@ public enum EventMatcherType {
         }
     },
 
-    /**
-     * We need to add multiple events to the issue transitioned cause Jira classic workflow send specific event types
-     * for each transition.
-     */
     ISSUE_TRANSITIONED("MATCHER:ISSUE_TRANSITIONED", new WorkflowStatusMatcher()) {
         @Override
         public <T, E extends Throwable> T accept(Visitor<T, E> visitor) throws E {

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/model/event/DefaultJiraIssueEvent.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/model/event/DefaultJiraIssueEvent.java
@@ -25,12 +25,14 @@ public class DefaultJiraIssueEvent implements JiraIssueEvent {
     private final Issue issue;
     private final Optional<Comment> comment;
     private final List<ChangeLogItem> changeLog;
+    private final String source;
 
     public static DefaultJiraIssueEvent of(final EventMatcherType eventMatcher,
                                            final IssueEvent issueEvent,
                                            final List<ChangeLogItem> changeLog) {
+        String source = String.format("IssueEvent[type=%d]", issueEvent.getEventTypeId());
         return new DefaultJiraIssueEvent(eventMatcher, Optional.ofNullable(issueEvent.getUser()), issueEvent.getIssue(),
-                Optional.ofNullable(issueEvent.getComment()), changeLog);
+                Optional.ofNullable(issueEvent.getComment()), changeLog, source);
     }
 
     public static DefaultJiraIssueEvent of(final EventMatcherType eventMatcher,
@@ -42,6 +44,6 @@ public class DefaultJiraIssueEvent implements JiraIssueEvent {
                 .collect(Collectors.toCollection(() -> new ArrayList<>(changeItems.size())));
 
         return new DefaultJiraIssueEvent(eventMatcher, issueChangedEvent.getAuthor(), issueChangedEvent.getIssue(),
-                issueChangedEvent.getComment(), changeLog);
+                issueChangedEvent.getComment(), changeLog, "IssueChangedEvent");
     }
 }

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/model/event/JiraIssueEvent.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/model/event/JiraIssueEvent.java
@@ -18,4 +18,5 @@ public interface JiraIssueEvent extends PluginEvent {
     Issue getIssue();
     Optional<Comment> getComment();
     List<ChangeLogItem> getChangeLog();
+    String getSource();
 }

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/service/issuefilter/impl/JqlIssueFilter.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/service/issuefilter/impl/JqlIssueFilter.java
@@ -40,10 +40,16 @@ public class JqlIssueFilter implements IssueFilter {
 
     @Override
     public boolean apply(final JiraIssueEvent event, final @NotNull String value) {
+        Issue issue = event.getIssue();
         try {
-            return matchesJql(value, event.getIssue(), event.getEventAuthor());
+            boolean isIssueMatched = matchesJql(value, issue, event.getEventAuthor());
+            log.debug("JQL matching result for issue key={}, id={}, source={}: {}", issue.getKey(), issue.getId(),
+                    event.getSource(), isIssueMatched);
+
+            return isIssueMatched;
         } catch (SearchException e) {
-            log.warn(" Search exception trying to match jql [{}] over issue []", value, event.getIssue().getId());
+            log.warn(" Search exception trying to match jql [{}] over issue key={}, id={}, source={}", value, issue.getKey(),
+                    issue.getId(), event.getSource());
         }
         return false;
     }

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/util/matcher/WorkflowStatusMatcher.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/util/matcher/WorkflowStatusMatcher.java
@@ -3,15 +3,25 @@ package com.atlassian.jira.plugins.slack.util.matcher;
 import com.atlassian.jira.issue.Issue;
 import com.atlassian.jira.plugins.slack.model.ProjectConfiguration;
 import com.atlassian.jira.plugins.slack.model.dto.MultipleValue;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * This workflow event matcher will check if the event
  * can be tracked
  */
+@Slf4j
 public class WorkflowStatusMatcher implements EventMatcher {
     @Override
-    public boolean matches(Issue issue, ProjectConfiguration config) {
-        final String id = issue.getStatus().getId();
-        return new MultipleValue(config.getValue()).apply(id);
+    public boolean matches(final Issue issue, final ProjectConfiguration config) {
+        final String issueStatusId = issue.getStatus().getId();
+        final String selectedStatusesIds = config.getValue();
+        final boolean isIssueMatched = new MultipleValue(selectedStatusesIds).apply(issueStatusId);
+
+        if (!isIssueMatched) {
+            log.debug("Issue key={}, id={} with status id={} isn't matched because status is absent in selected statuses list: [{}]",
+                    issue.getKey(), issue.getId(), issueStatusId, selectedStatusesIds);
+        }
+
+        return isIssueMatched;
     }
 }

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/test/java/com/atlassian/jira/plugins/slack/service/listener/impl/DefaultIssueEventToEventMatcherTypeConverterTest.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/test/java/com/atlassian/jira/plugins/slack/service/listener/impl/DefaultIssueEventToEventMatcherTypeConverterTest.java
@@ -1,9 +1,12 @@
 package com.atlassian.jira.plugins.slack.service.listener.impl;
 
+import com.atlassian.jira.event.issue.IssueChangedEvent;
+import com.atlassian.jira.event.issue.IssueChangedEventImpl;
 import com.atlassian.jira.event.issue.IssueEvent;
 import com.atlassian.jira.event.type.EventType;
 import com.atlassian.jira.issue.Issue;
 import com.atlassian.jira.issue.comments.Comment;
+import com.atlassian.jira.issue.history.ChangeItemBean;
 import com.atlassian.jira.plugins.slack.model.EventMatcherType;
 import com.atlassian.jira.plugins.slack.util.changelog.ChangeLogExtractor;
 import com.atlassian.jira.plugins.slack.util.changelog.ChangeLogItem;
@@ -16,6 +19,9 @@ import org.mockito.junit.MockitoRule;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
 
 import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertThat;
@@ -51,11 +57,11 @@ public class DefaultIssueEventToEventMatcherTypeConverterTest {
 
     @Test
     public void match_forIssueTransition() {
-        IssueEvent issueEvent = new IssueEvent(issue, Collections.emptyMap(), null, EventType.ISSUE_CLOSED_ID);
-        when(changeLogExtractor.getChanges(issueEvent)).thenReturn(Collections.singletonList(changeLogItem));
-        when(changeLogItem.getField()).thenReturn(ChangeLogExtractor.STATUS_FIELD_NAME);
+        List<ChangeItemBean> changeItems = Collections.singletonList(new ChangeItemBean("fieldType",
+                ChangeLogExtractor.STATUS_FIELD_NAME, null, null));
+        IssueChangedEvent event = new IssueChangedEventImpl(issue, Optional.empty(), changeItems, Optional.empty(), new Date(), false, null);
 
-        Collection<EventMatcherType> result = target.match(issueEvent);
+        Collection<EventMatcherType> result = target.match(event);
 
         assertThat(result, contains(EventMatcherType.ISSUE_TRANSITIONED));
     }

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/test/java/com/atlassian/jira/plugins/slack/service/listener/impl/DefaultJiraSlackEventListenerTest.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/test/java/com/atlassian/jira/plugins/slack/service/listener/impl/DefaultJiraSlackEventListenerTest.java
@@ -19,6 +19,7 @@ import com.atlassian.jira.plugins.slack.service.task.TaskBuilder;
 import com.atlassian.jira.plugins.slack.service.task.TaskExecutorService;
 import com.atlassian.jira.plugins.slack.service.task.impl.SendNotificationTask;
 import com.atlassian.jira.plugins.slack.settings.JiraSettingsService;
+import com.atlassian.jira.plugins.slack.util.changelog.ChangeLogExtractor;
 import com.atlassian.jira.user.ApplicationUser;
 import com.atlassian.plugins.slack.analytics.AnalyticsContextProvider;
 import com.atlassian.plugins.slack.api.notification.Verbosity;
@@ -76,6 +77,8 @@ public class DefaultJiraSlackEventListenerTest {
     private AnalyticsContextProvider analyticsContextProvider;
     @Mock
     private AsyncExecutor asyncExecutor;
+    @Mock
+    private ChangeLogExtractor changeLogExtractor;
 
     @Mock
     private ApplicationUser applicationUser;

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/test/java/com/atlassian/jira/plugins/slack/service/notification/impl/DefaultIssueEventProcessorServiceTest.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/test/java/com/atlassian/jira/plugins/slack/service/notification/impl/DefaultIssueEventProcessorServiceTest.java
@@ -9,7 +9,6 @@ import com.atlassian.jira.plugins.slack.manager.impl.DefaultProjectConfiguration
 import com.atlassian.jira.plugins.slack.model.EventFilterType;
 import com.atlassian.jira.plugins.slack.model.EventMatcherType;
 import com.atlassian.jira.plugins.slack.model.ProjectConfiguration;
-import com.atlassian.jira.plugins.slack.model.event.DefaultJiraIssueEvent;
 import com.atlassian.jira.plugins.slack.model.event.JiraIssueEvent;
 import com.atlassian.jira.plugins.slack.service.issuefilter.IssueFilterService;
 import com.atlassian.jira.plugins.slack.service.notification.NotificationInfo;
@@ -30,7 +29,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import static java.util.Collections.emptyList;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
@@ -77,9 +75,6 @@ public class DefaultIssueEventProcessorServiceTest {
 
     @Test
     public void getNotificationsFor_shouldReturnNotifications_whenIssueIsCreated() {
-        IssueEvent issueEvent = new IssueEvent(issue, Collections.emptyMap(), null, 1L);
-        DefaultJiraIssueEvent jiraIssueEvent = DefaultJiraIssueEvent.of(EventMatcherType.ISSUE_CREATED, issueEvent, emptyList());
-
         when(issue.getProjectObject()).thenReturn(project);
         when(project.getId()).thenReturn(7L);
         when(event.getEventMatcher()).thenReturn(EventMatcherType.ISSUE_CREATED);
@@ -106,7 +101,7 @@ public class DefaultIssueEventProcessorServiceTest {
                 .thenReturn(Arrays.asList(projectConfiguration1, projectConfiguration2));
         when(configurationDAO.findByProjectConfigurationGroupId(7L, "G2"))
                 .thenReturn(Arrays.asList(projectConfiguration3, projectConfiguration4));
-        when(filterService.apply(jiraIssueEvent, Collections.singletonList(projectConfiguration4))).thenReturn(true);
+        when(filterService.apply(event, Collections.singletonList(projectConfiguration4))).thenReturn(true);
         when(projectConfigurationManager.getOwner(projectConfiguration1)).thenReturn(Optional.of("O1"));
         when(projectConfigurationManager.getOwner(projectConfiguration3)).thenReturn(Optional.of("O2"));
         when(projectConfigurationManager.getVerbosity(projectConfiguration1)).thenReturn(Optional.of(Verbosity.BASIC));
@@ -131,13 +126,12 @@ public class DefaultIssueEventProcessorServiceTest {
         long projectId = 7L;
         String groupId = "G";
 
-        when(issueEvent.getIssue()).thenReturn(issue);
-        when(issueEvent.getProject()).thenReturn(project);
-        when(issueEvent.getComment()).thenReturn(comment);
-        when(project.getId()).thenReturn(projectId);
-        when(comment.getGroupLevel()).thenReturn("someGroupLevel");
         when(event.getEventMatcher()).thenReturn(EventMatcherType.ISSUE_COMMENTED);
         when(event.getIssue()).thenReturn(issue);
+        when(event.getComment()).thenReturn(Optional.of(comment));
+        when(issue.getProjectObject()).thenReturn(project);
+        when(project.getId()).thenReturn(projectId);
+        when(comment.getGroupLevel()).thenReturn("someGroupLevel");
         when(configurationDAO.findByProjectId(projectId)).thenReturn(Arrays.asList(projectConfiguration1,
                 projectConfiguration2));
         when(projectConfiguration1.getConfigurationGroupId()).thenReturn(groupId);

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/test/java/com/atlassian/jira/plugins/slack/service/notification/impl/JiraIssueEventRendererTest.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/test/java/com/atlassian/jira/plugins/slack/service/notification/impl/JiraIssueEventRendererTest.java
@@ -1,6 +1,5 @@
 package com.atlassian.jira.plugins.slack.service.notification.impl;
 
-import com.atlassian.jira.event.issue.IssueEvent;
 import com.atlassian.jira.issue.MutableIssue;
 import com.atlassian.jira.issue.comments.Comment;
 import com.atlassian.jira.issue.issuetype.IssueType;
@@ -31,20 +30,20 @@ import org.mockito.junit.MockitoRule;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 public class JiraIssueEventRendererTest {
     @Mock
     private I18nResolver i18nResolver;
-    @Mock
-    private ChangeLogExtractor changeLogExtractor;
     @Mock
     private AttachmentHelper attachmentHelper;
     @Mock
@@ -120,8 +119,9 @@ public class JiraIssueEventRendererTest {
         when(i18nResolver.getText("jira.slack.card.notification.event.updated", "ulink", "a", "Bug", "")).thenReturn("txt");
         when(attachmentHelper.buildIssueAttachment(null, issue, Collections.singletonList(f))).thenReturn(attachment);
         when(jiraIssueEvent.getEventMatcher()).thenReturn(EventMatcherType.ISSUE_UPDATED);
-        when(changeLogExtractor.getChanges(ArgumentMatchers.any(), eq(1000))).thenReturn(Collections.singletonList(changeLogItem));
+        when(jiraIssueEvent.getChangeLog()).thenReturn(Collections.singletonList(changeLogItem));
         when(changeLogItem.getNewText()).thenReturn("N");
+        when(changeLogItem.getNewTextTruncated(anyInt())).thenReturn("N");
         when(changeLogItem.getField()).thenReturn("F");
 
         SlackNotification notif = testRender(Verbosity.EXTENDED);
@@ -139,9 +139,11 @@ public class JiraIssueEventRendererTest {
                 "", "OLD", "S")).thenReturn("txt");
         when(attachmentHelper.buildIssueAttachment(null, issue, null)).thenReturn(attachment);
         when(jiraIssueEvent.getEventMatcher()).thenReturn(EventMatcherType.ISSUE_TRANSITIONED);
-        when(changeLogExtractor.getChanges(ArgumentMatchers.any(), eq(1000))).thenReturn(Collections.singletonList(changeLogItem));
+        when(jiraIssueEvent.getChangeLog()).thenReturn(Collections.singletonList(changeLogItem));
         when(changeLogItem.getOldText()).thenReturn("OLD");
+        when(changeLogItem.getOldTextTruncated(anyInt())).thenReturn("OLD");
         when(changeLogItem.getNewText()).thenReturn("N");
+        when(changeLogItem.getNewTextTruncated(anyInt())).thenReturn("N");
         when(changeLogItem.getField()).thenReturn(ChangeLogExtractor.STATUS_FIELD_NAME);
 
         SlackNotification notif = testRender(Verbosity.EXTENDED);
@@ -159,7 +161,7 @@ public class JiraIssueEventRendererTest {
                 .thenReturn("txt");
         when(attachmentHelper.buildIssueAttachment(null, issue, null)).thenReturn(attachment);
         when(jiraIssueEvent.getEventMatcher()).thenReturn(EventMatcherType.ISSUE_TRANSITIONED);
-        when(changeLogExtractor.getChanges(ArgumentMatchers.any(), eq(1000))).thenReturn(Collections.singletonList(changeLogItem));
+        when(jiraIssueEvent.getChangeLog()).thenReturn(Collections.singletonList(changeLogItem));
         when(changeLogItem.getOldText()).thenReturn("");
         when(changeLogItem.getNewText()).thenReturn("N");
         when(changeLogItem.getField()).thenReturn(ChangeLogExtractor.STATUS_FIELD_NAME);
@@ -226,7 +228,7 @@ public class JiraIssueEventRendererTest {
                 "olink", "nlink")).thenReturn("txt");
         when(attachmentHelper.buildIssueAttachment(null, issue, null)).thenReturn(attachment);
         when(jiraIssueEvent.getEventMatcher()).thenReturn(EventMatcherType.ISSUE_ASSIGNMENT_CHANGED);
-        when(changeLogExtractor.getChanges(ArgumentMatchers.any(), eq(1000))).thenReturn(Collections.singletonList(changeLogItem));
+        when(jiraIssueEvent.getChangeLog()).thenReturn(Collections.singletonList(changeLogItem));
         when(changeLogItem.getField()).thenReturn(ChangeLogExtractor.ASSIGNEE_FIELD_NAME);
         when(changeLogItem.getOldValue()).thenReturn("OLDV");
         when(changeLogItem.getNewValue()).thenReturn("NEWV");
@@ -249,7 +251,7 @@ public class JiraIssueEventRendererTest {
                 .thenReturn("txt");
         when(attachmentHelper.buildIssueAttachment(null, issue, null)).thenReturn(attachment);
         when(jiraIssueEvent.getEventMatcher()).thenReturn(EventMatcherType.ISSUE_ASSIGNMENT_CHANGED);
-        when(changeLogExtractor.getChanges(ArgumentMatchers.any(), eq(1000))).thenReturn(Collections.singletonList(changeLogItem));
+        when(jiraIssueEvent.getChangeLog()).thenReturn(Collections.singletonList(changeLogItem));
         when(changeLogItem.getField()).thenReturn(ChangeLogExtractor.ASSIGNEE_FIELD_NAME);
         when(changeLogItem.getOldValue()).thenReturn("");
         when(changeLogItem.getNewValue()).thenReturn("NEWV");
@@ -270,7 +272,7 @@ public class JiraIssueEventRendererTest {
                 .thenReturn("txt");
         when(attachmentHelper.buildIssueAttachment(null, issue, null)).thenReturn(attachment);
         when(jiraIssueEvent.getEventMatcher()).thenReturn(EventMatcherType.ISSUE_ASSIGNMENT_CHANGED);
-        when(changeLogExtractor.getChanges(ArgumentMatchers.any(), eq(1000))).thenReturn(Collections.singletonList(changeLogItem));
+        when(jiraIssueEvent.getChangeLog()).thenReturn(Collections.singletonList(changeLogItem));
         when(changeLogItem.getField()).thenReturn(ChangeLogExtractor.ASSIGNEE_FIELD_NAME);
         when(changeLogItem.getOldValue()).thenReturn("OLDV");
         when(changeLogItem.getNewValue()).thenReturn(null);
@@ -291,7 +293,7 @@ public class JiraIssueEventRendererTest {
                 .thenReturn("txt");
         when(attachmentHelper.buildIssueAttachment(null, issue, null)).thenReturn(attachment);
         when(jiraIssueEvent.getEventMatcher()).thenReturn(EventMatcherType.ISSUE_ASSIGNMENT_CHANGED);
-        when(changeLogExtractor.getChanges(ArgumentMatchers.any(), eq(1000))).thenReturn(Collections.singletonList(changeLogItem));
+        when(jiraIssueEvent.getChangeLog()).thenReturn(Collections.singletonList(changeLogItem));
         when(changeLogItem.getField()).thenReturn(ChangeLogExtractor.ASSIGNEE_FIELD_NAME);
         when(changeLogItem.getOldValue()).thenReturn(null);
         when(changeLogItem.getNewValue()).thenReturn(null);
@@ -305,8 +307,9 @@ public class JiraIssueEventRendererTest {
     }
 
     private SlackNotification testRender(final Verbosity verbosity) {
-        IssueEvent issueEvent = new IssueEvent(issue, applicationUser, comment, null, null, Collections.emptyMap(), 1L);
         when(jiraIssueEvent.getIssue()).thenReturn(issue);
+        when(jiraIssueEvent.getComment()).thenReturn(Optional.of(comment));
+        when(jiraIssueEvent.getEventAuthor()).thenReturn(Optional.of(applicationUser));
         when(notificationInfo.getLink()).thenReturn(link);
         when(notificationInfo.getChannelId()).thenReturn("C");
         when(notificationInfo.getResponseUrl()).thenReturn("url");

--- a/pom.xml
+++ b/pom.xml
@@ -50,8 +50,8 @@
         <slf4j.version>1.7.25</slf4j.version>
         <sal.api.version>3.1.0</sal.api.version>
         <mockito-core.version>2.25.0</mockito-core.version>
-        <junit.version>4.13.1</junit.version>
-        <junit.jupiter.version>5.5.1</junit.jupiter.version>
+        <junit.version>4.13.2</junit.version>
+        <junit.jupiter.version>5.7.1</junit.jupiter.version>
         <rest.version>2.9.2</rest.version>
         <joda-time.version>2.3</joda-time.version>
         <io.fugue.version>4.7.2</io.fugue.version>


### PR DESCRIPTION
1. After bumping JUnit in #98 JUnit tests that were run by Jupiter engines stopped running. They were silently ignored and didn't even fail the build. I accidentally discovered it just today. I upgraded Jupiter to the latest version and it worked! 
2. Tests started running again and it appeared that a lot of them are failing. Not because of the issue in the plugin code, just due to outdated tests. I fixed them all as well.
3. There is another issue in Jira plugin that was reported by customers: some project configurations don't have an owner assigned (probably because of downgrade after running a DB migration) and they stopped sending notifications. It is also fixed.