### PR TITLE
#117: Made integration tests compatible with Jira 8.17.1

### DIFF
--- a/bin/build/run-jira-its.sh
+++ b/bin/build/run-jira-its.sh
@@ -6,11 +6,19 @@ TOMCAT_VERSION=${TOMCAT_VERSION:-tomcat8x}
 
 # Support Jira 8
 if [[ ${VERSION} == 8* ]] ; then
-    TESTKIT_VERSION=${TESTKIT_VERSION:-8.1.25}
+    TESTKIT_VERSION=${TESTKIT_VERSION:-8.1.28}
 fi
+
+# Version less than or equal
+# https://stackoverflow.com/a/4024263
+verlte() {
+    [  "$1" = "$(echo -e "$1\n$2" | sort -V | head -n1)" ]
+}
 
 VERSION_ARG=$([[ -z ${VERSION} ]] && echo "" || echo "-Djira.version=${VERSION} -Dproduct.version=${VERSION}")
 TESTKIT_VERSION_ARG=$([[ -z ${TESTKIT_VERSION} ]] && echo "" || echo "-Dtestkit.version=${TESTKIT_VERSION}")
+# override Selenium version for Jira versions starting with 8.17.1
+SELENIUM_VERSION_ARG=$([[ -z ${VERSION} ]] || verlte ${VERSION} '8.17.0' && echo "" || echo "-Datlassian.selenium.version=3.2.4")
 
 export DANGER_MODE=true
 
@@ -21,6 +29,7 @@ fi
 atlas-mvn --batch-mode verify \
   ${VERSION_ARG} \
   ${TESTKIT_VERSION_ARG} \
+  ${SELENIUM_VERSION_ARG} \
   -Dut.test.skip=true \
   -Dit.test.skip=false \
   -Dcontainer=${TOMCAT_VERSION} \

--- a/confluence-slack-server-integration-plugin/pom.xml
+++ b/confluence-slack-server-integration-plugin/pom.xml
@@ -217,17 +217,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>com.atlassian.selenium</groupId>
-            <artifactId>atlassian-webdriver-core</artifactId>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <artifactId>junit</artifactId>
-                    <groupId>junit</groupId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
             <scope>test</scope>

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/pom.xml
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/pom.xml
@@ -88,11 +88,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>com.atlassian.sal</groupId>
             <artifactId>sal-api</artifactId>
             <scope>provided</scope>
@@ -245,11 +240,6 @@
             <artifactId>powermock-module-junit4</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>com.atlassian.jira</groupId>
-            <artifactId>jira-webdriver-tests</artifactId>
-            <scope>test</scope>
-        </dependency>
 
         <!-- integration tests -->
         <dependency>
@@ -270,11 +260,6 @@
         <dependency>
             <groupId>com.atlassian.httpclient</groupId>
             <artifactId>atlassian-httpclient-apache-httpcomponents</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.atlassian.selenium</groupId>
-            <artifactId>atlassian-webdriver-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <rest.version>2.9.2</rest.version>
         <joda-time.version>2.3</joda-time.version>
         <io.fugue.version>4.7.2</io.fugue.version>
-        <commons-lang3.version>3.3.2</commons-lang3.version>
+        <commons-lang3.version>3.8</commons-lang3.version>
         <commons-codec.version>1.11</commons-codec.version>
         <jackson.version>2.9.2</jackson.version>
         <atlassian-annotations.version>2.1.0</atlassian-annotations.version>
@@ -122,13 +122,6 @@
                 <version>1.1.1</version>
                 <scope>provided</scope>
             </dependency>
-            <dependency>
-                <groupId>com.atlassian.browsers</groupId>
-                <artifactId>atlassian-browsers-auto</artifactId>
-                <version>2.8.8</version>
-                <scope>test</scope>
-            </dependency>
-
             <dependency>
                 <groupId>com.github.seratch</groupId>
                 <artifactId>jslack</artifactId>

--- a/slack-server-integration-common/pom.xml
+++ b/slack-server-integration-common/pom.xml
@@ -177,11 +177,6 @@
 
         <!-- Test dependencies-->
         <dependency>
-            <groupId>com.atlassian.selenium</groupId>
-            <artifactId>atlassian-webdriver-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>
@@ -219,11 +214,6 @@
         <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.atlassian.selenium</groupId>
-            <artifactId>atlassian-pageobjects-elements</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Release checker have created tickets for compatibility with Jira 8.17.0 and Jira 8.17.1 recently and all integrations tests failed for that versions. As far I understood it happened because Jira team upgraded some libraries used in integration tests, but Slack plugins continued to use hard-coded versions of the libraries. I removed some hard-coded test dependencies where it was possible, and added an override of system property `atlassian.selenium.version` in integration tests for Jira 8.17.1 and newer. It allowed to run integration tests on oldest and newest supported versions.

Here are the successful integration test runs against Jira 8.17.1 in this branch:
* Java 8: https://github.com/atlassian-labs/atlassian-slack-integration-server/runs/2989172142?check_suite_focus=true
* Java 11: https://github.com/atlassian-labs/atlassian-slack-integration-server/runs/2989174718?check_suite_focus=true