### PR TITLE
Prevent triggering full reindex

### DIFF
--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/bridge/jql/impl/JqlIndexSearcher.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/bridge/jql/impl/JqlIndexSearcher.java
@@ -2,6 +2,7 @@ package com.atlassian.jira.plugins.slack.bridge.jql.impl;
 
 import com.atlassian.jira.issue.Issue;
 import com.atlassian.jira.issue.index.IndexException;
+import com.atlassian.jira.issue.index.IssueIndexingParams;
 import com.atlassian.jira.issue.index.IssueIndexingService;
 import com.atlassian.jira.issue.index.ThreadLocalSearcherCache;
 import com.atlassian.jira.issue.search.SearchException;
@@ -71,7 +72,7 @@ public class JqlIndexSearcher implements JqlSearcher {
         ImportUtils.setIndexIssues(true);
 
         try {
-            indexingService.reIndex(issue);
+            indexingService.reIndex(issue, IssueIndexingParams.INDEX_ISSUE_ONLY);
         } catch (IndexException e) {
             log.error("An error occurred during the issue {} reindex", issue.getId(), e);
         } finally {

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/test/java/com/atlassian/jira/plugins/slack/bridge/jql/impl/JqlIndexSearcherTest.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/test/java/com/atlassian/jira/plugins/slack/bridge/jql/impl/JqlIndexSearcherTest.java
@@ -1,6 +1,7 @@
 package com.atlassian.jira.plugins.slack.bridge.jql.impl;
 
 import com.atlassian.jira.issue.Issue;
+import com.atlassian.jira.issue.index.IssueIndexingParams;
 import com.atlassian.jira.issue.index.IssueIndexingService;
 import com.atlassian.jira.issue.search.SearchProvider;
 import com.atlassian.jira.issue.search.SearchQuery;
@@ -51,7 +52,7 @@ public class JqlIndexSearcherTest {
         boolean result = target.doesIssueMatchQuery(issue, applicationUser, query);
 
         assertThat(result, is(true));
-        verify(indexingService).reIndex(issue);
+        verify(indexingService).reIndex(issue, IssueIndexingParams.INDEX_ISSUE_ONLY);
     }
 
     @Test
@@ -61,7 +62,7 @@ public class JqlIndexSearcherTest {
         boolean result = target.doesIssueMatchQuery(issue, applicationUser, query);
 
         assertThat(result, is(false));
-        verify(indexingService).reIndex(issue);
+        verify(indexingService).reIndex(issue, IssueIndexingParams.INDEX_ISSUE_ONLY);
     }
 
     @Test
@@ -71,7 +72,7 @@ public class JqlIndexSearcherTest {
         boolean result = target.doesIssueMatchQuery(issue, null, query);
 
         assertThat(result, is(true));
-        verify(indexingService).reIndex(issue);
+        verify(indexingService).reIndex(issue, IssueIndexingParams.INDEX_ISSUE_ONLY);
     }
 
     @Test
@@ -81,6 +82,6 @@ public class JqlIndexSearcherTest {
         boolean result = target.doesIssueMatchQuery(issue, null, query);
 
         assertThat(result, is(false));
-        verify(indexingService).reIndex(issue);
+        verify(indexingService).reIndex(issue, IssueIndexingParams.INDEX_ISSUE_ONLY);
     }
 }


### PR DESCRIPTION
There were reports of scaling problems caused by the plugin reindexing more than necessary.