### PR TITLE
Fixed leaking color syntax from Jira to Slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ Running `$JAVA_HOME/bin/java -version` should print a JDK version.
 2. Download and install [Atlassian Plugin SDK](https://developer.atlassian.com/server/framework/atlassian-sdk/install-the-atlassian-sdk-on-a-linux-or-mac-system/). 
 After successful installation running `atlas-version` should print SDK version.
 3. (Optional) Install [ngrok](https://ngrok.com/) to enable Slack -> product features (slash commands, unfurling). 
-If you don't have ngrok, the plugin still can send notification to Slack in uni-derectional way.
+If you don't have ngrok, the plugin still can send notification to Slack in uni-directional way. 
+Slack demands HTTPS OAuth redirect URLs, so you also need to add your ngrok host to domain allowlist at
+http://localhost:2990/jira/plugins/servlet/whitelist. 
 4. If you are setting up the project for the first time run `./jira.sh common` from the project root directory to install 
 all common modules to local Maven repository.
 5. Go to **\<product> Plugin Development** section for further steps. 

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/pom.xml
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/pom.xml
@@ -192,6 +192,13 @@
         <!-- Test dependencies-->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>5.8.1</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/service/notification/impl/DefaultAttachmentHelper.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/service/notification/impl/DefaultAttachmentHelper.java
@@ -38,7 +38,6 @@ public class DefaultAttachmentHelper implements AttachmentHelper {
     private final I18nResolver i18nResolver;
     private final AvatarService avatarService;
     private final I18nHelper i18nHelper;
-  //  private CommentUtil commentUtil;
 
     private final SlackSettingService slackSettingService;
 

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/service/notification/impl/DefaultAttachmentHelper.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/service/notification/impl/DefaultAttachmentHelper.java
@@ -7,6 +7,7 @@ import com.atlassian.jira.issue.Issue;
 import com.atlassian.jira.issue.IssueConstant;
 import com.atlassian.jira.issue.comments.Comment;
 import com.atlassian.jira.plugins.slack.service.notification.AttachmentHelper;
+import com.atlassian.jira.plugins.slack.util.CommentUtil;
 import com.atlassian.jira.project.Project;
 import com.atlassian.jira.security.JiraAuthenticationContext;
 import com.atlassian.jira.user.ApplicationUser;
@@ -37,6 +38,7 @@ public class DefaultAttachmentHelper implements AttachmentHelper {
     private final I18nResolver i18nResolver;
     private final AvatarService avatarService;
     private final I18nHelper i18nHelper;
+  //  private CommentUtil commentUtil;
 
     private final SlackSettingService slackSettingService;
 
@@ -103,6 +105,7 @@ public class DefaultAttachmentHelper implements AttachmentHelper {
 
     @Override
     public Attachment buildCommentAttachment(final String pretext, final Issue issue, final Comment comment) {
+        String cleanCommentBody = CommentUtil.removeJiraTags(comment.getBody());
         return Attachment.builder()
                 .pretext(pretext)
                 .title(i18nResolver.getText("jira.slack.card.notification.issue.title", issue.getKey(), issue.getSummary()))
@@ -112,7 +115,7 @@ public class DefaultAttachmentHelper implements AttachmentHelper {
                         .build()
                         .toString(), "comment"))
                 .fallback(issue.getKey() + ": " + defaultString(pretext))
-                .text(comment.getBody())
+                .text(cleanCommentBody)
                 .footer(footerText(issue.getProjectObject()))
                 .footerIcon(projectIcon(issue.getProjectObject()))
                 .color("#2684FF")

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/service/notification/impl/JiraIssueEventRenderer.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/service/notification/impl/JiraIssueEventRenderer.java
@@ -9,6 +9,7 @@ import com.atlassian.jira.plugins.slack.model.event.PluginEvent;
 import com.atlassian.jira.plugins.slack.service.notification.AttachmentHelper;
 import com.atlassian.jira.plugins.slack.service.notification.MessageRendererException;
 import com.atlassian.jira.plugins.slack.service.notification.NotificationInfo;
+import com.atlassian.jira.plugins.slack.util.CommentUtil;
 import com.atlassian.jira.plugins.slack.util.changelog.ChangeLogExtractor;
 import com.atlassian.jira.plugins.slack.util.changelog.ChangeLogItem;
 import com.atlassian.jira.user.util.UserManager;
@@ -179,8 +180,9 @@ public class JiraIssueEventRenderer extends AbstractEventRenderer<JiraIssueEvent
                                 isExtendedVerbosity ? "" : attachmentHelper.issueLink(issue)
                         );
                         String commentBody = comment != null ? comment.getBody() : "";
+                        String cleanCommentBody = CommentUtil.removeJiraTags(commentBody);
                         return ChatPostMessageRequest.builder()
-                                .text(isExtendedVerbosity ? text : text + String.format(": _%s_", commentBody))
+                                .text(isExtendedVerbosity ? text : text + String.format(": _%s_", cleanCommentBody))
                                 .mrkdwn(true)
                                 .attachments(buildAttachments(isExtendedVerbosity,
                                         () -> attachmentHelper.buildCommentAttachment(null, issue, comment)));

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/util/CommentUtil.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/util/CommentUtil.java
@@ -11,4 +11,16 @@ public class CommentUtil {
         return comment != null
                 && (comment.getGroupLevel() != null || comment.getRoleLevelId() != null);
     }
+
+    public static String removeJiraTags(final @Nullable String commentBody) {
+        if(commentBody==null) {
+            return "";
+        }
+        return commentBody
+                .replaceAll("\\{color(?::[^}]+)?}", "")
+                .replace("{quote}", "")
+                .replace("{noformat}", "")
+                .replaceAll("\\{panel(?::[^}]+)?}", "")
+                .replaceAll("\\{code(?::[^}]+)?}", "");
+    }
 }

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/util/CommentUtil.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/util/CommentUtil.java
@@ -13,7 +13,7 @@ public class CommentUtil {
     }
 
     public static String removeJiraTags(final @Nullable String commentBody) {
-        if(commentBody==null) {
+        if (commentBody == null) {
             return "";
         }
         return commentBody

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/test/java/com/atlassian/jira/plugins/slack/util/CommentUtilTest.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/test/java/com/atlassian/jira/plugins/slack/util/CommentUtilTest.java
@@ -1,0 +1,42 @@
+package com.atlassian.jira.plugins.slack.util;
+
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CommentUtilTest {
+
+    @Test
+    void testRemoveJiraTagsRemovesValidTags() {
+        assertEquals("Some text with a title",
+                CommentUtil.removeJiraTags("{panel:title=My Title}Some text with a title{panel}"));
+        assertEquals("look ma, red text!",
+                CommentUtil.removeJiraTags("{color:red}look ma, red text!{color}"));
+        assertEquals("here is quotable content to be quoted",
+                CommentUtil.removeJiraTags("{quote}here is quotable content to be quoted{quote}"));
+        assertEquals("preformatted piece",
+                CommentUtil.removeJiraTags("{noformat}preformatted piece{noformat}"));
+        assertEquals("some text",
+                CommentUtil.removeJiraTags("{code:title=Bar.java|borderStyle=solid}some text{code}"));
+    }
+
+
+    @Test
+    void testRemoveJiraTagsDoesNotRemoveInvalidTags() {
+        assertEquals("{panell:title=My Title}Some text with a title",
+                CommentUtil.removeJiraTags("{panell:title=My Title}Some text with a title{panel}"));
+        assertEquals("{color }look ma, red text!",
+                CommentUtil.removeJiraTags("{color }look ma, red text!{color}"));
+        assertEquals("here is quotable content to be quoted{q1uote}",
+                CommentUtil.removeJiraTags("{quote}here is quotable content to be quoted{q1uote}"));
+        assertEquals("{noformat:}preformatted piece",
+                CommentUtil.removeJiraTags("{noformat:}preformatted piece{noformat}"));
+        assertEquals("some text{coode}",
+                CommentUtil.removeJiraTags("{code:title=Bar.java|borderStyle=solid}some text{coode}"));
+        assertEquals("{notsupperted}message{notsupported}",
+                CommentUtil.removeJiraTags("{notsupperted}message{notsupported}"));
+        assertEquals("", CommentUtil.removeJiraTags(null));
+    }
+
+}

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/test/java/com/atlassian/jira/plugins/slack/util/CommentUtilTest.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/test/java/com/atlassian/jira/plugins/slack/util/CommentUtilTest.java
@@ -1,42 +1,51 @@
 package com.atlassian.jira.plugins.slack.util;
 
-
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-import static org.junit.jupiter.api.Assertions.*;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import static org.junit.Assert.assertEquals;
 
 class CommentUtilTest {
-
-    @Test
-    void testRemoveJiraTagsRemovesValidTags() {
-        assertEquals("Some text with a title",
-                CommentUtil.removeJiraTags("{panel:title=My Title}Some text with a title{panel}"));
-        assertEquals("look ma, red text!",
-                CommentUtil.removeJiraTags("{color:red}look ma, red text!{color}"));
-        assertEquals("here is quotable content to be quoted",
-                CommentUtil.removeJiraTags("{quote}here is quotable content to be quoted{quote}"));
-        assertEquals("preformatted piece",
-                CommentUtil.removeJiraTags("{noformat}preformatted piece{noformat}"));
-        assertEquals("some text",
-                CommentUtil.removeJiraTags("{code:title=Bar.java|borderStyle=solid}some text{code}"));
+    @ParameterizedTest
+    @MethodSource("validTagsProvider")
+    void testRemoveJiraTagsRemovesValidTags(String argument) {
+        assertEquals("some text", CommentUtil.removeJiraTags(argument));
     }
 
+    static Stream<String> validTagsProvider() {
+        return Stream.of("{panel:title=My Title}some text{panel}",
+                "{color:red}some text{color}",
+                "{quote}some text{quote}",
+                "{noformat}some text{noformat}",
+                "{code:title=Bar.java|borderStyle=solid}some text{code}");
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidTagsProvider")
+    void testRemoveJiraTagsDoesNotRemoveInvalidTags(String argument) {
+        assertEquals(argument, CommentUtil.removeJiraTags(argument));
+    }
+
+    static Stream<String> invalidTagsProvider() {
+        return Stream.of("{panell:title=My Title}some text{panell}",
+                "{colr:red}some text{colrr}",
+                "{quote }some text{quotee}",
+                "{noformat:}some text{noformat:}",
+                "{code :title=Bar.java|borderStyle=solid}some text{cod}");
+    }
 
     @Test
-    void testRemoveJiraTagsDoesNotRemoveInvalidTags() {
-        assertEquals("{panell:title=My Title}Some text with a title",
-                CommentUtil.removeJiraTags("{panell:title=My Title}Some text with a title{panel}"));
-        assertEquals("{color }look ma, red text!",
-                CommentUtil.removeJiraTags("{color }look ma, red text!{color}"));
-        assertEquals("here is quotable content to be quoted{q1uote}",
-                CommentUtil.removeJiraTags("{quote}here is quotable content to be quoted{q1uote}"));
-        assertEquals("{noformat:}preformatted piece",
-                CommentUtil.removeJiraTags("{noformat:}preformatted piece{noformat}"));
-        assertEquals("some text{coode}",
-                CommentUtil.removeJiraTags("{code:title=Bar.java|borderStyle=solid}some text{coode}"));
-        assertEquals("{notsupperted}message{notsupported}",
-                CommentUtil.removeJiraTags("{notsupperted}message{notsupported}"));
-        assertEquals("", CommentUtil.removeJiraTags(null));
+    @Timeout(value = 1, unit = TimeUnit.SECONDS)
+    void test_this() {
+        assertEquals("{{{{{{{{{{{{{{{{{{{{{{{}}}}}}}}}}}}}}}}}}}}}}}}text",
+                CommentUtil.removeJiraTags("{{{{{{{{{{{{{{{{{{{{{{{{color}}}}}}}}}}}}}}}}}}}}}}}}}text"));
+        assertEquals("{quote{quote{quote{quote{quote{quote{quote{quote}}}}}text",
+                CommentUtil.removeJiraTags("{quote{quote{quote{quote{quote{quote{quote{quote{quote}}}}}}text{quote}"));
     }
 
 }

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/test/java/com/atlassian/jira/plugins/slack/util/CommentUtilTest.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/test/java/com/atlassian/jira/plugins/slack/util/CommentUtilTest.java
@@ -41,7 +41,7 @@ class CommentUtilTest {
 
     @Test
     @Timeout(value = 1, unit = TimeUnit.SECONDS)
-    void test_this() {
+    void testRemoveJiraTagsMatchesComplexInputFastEnough() {
         assertEquals("{{{{{{{{{{{{{{{{{{{{{{{}}}}}}}}}}}}}}}}}}}}}}}}text",
                 CommentUtil.removeJiraTags("{{{{{{{{{{{{{{{{{{{{{{{{color}}}}}}}}}}}}}}}}}}}}}}}}}text"));
         assertEquals("{quote{quote{quote{quote{quote{quote{quote{quote}}}}}text",


### PR DESCRIPTION
Valid Jira text formatting syntax is rendered correctly in Jira, but is shown in raw form in Slack notifications. If text was coloured, Slack added color tags to comment. To fix this bug, i used regex to get the message without tags.