### PR TITLE
Bump okhttp3 to 3.14.9

### DIFF
--- a/bitbucket-slack-server-integration-plugin/pom.xml
+++ b/bitbucket-slack-server-integration-plugin/pom.xml
@@ -66,6 +66,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>com.squareup.okhttp3</groupId>
+                <artifactId>okhttp</artifactId>
+                <version>3.14.9</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -525,8 +525,13 @@
 
             <dependency>
                 <groupId>com.squareup.okhttp3</groupId>
+                <artifactId>okhttp</artifactId>
+                <version>3.14.9</version>
+            </dependency>
+            <dependency>
+                <groupId>com.squareup.okhttp3</groupId>
                 <artifactId>mockwebserver</artifactId>
-                <version>3.14.1</version>
+                <version>3.14.9</version>
                 <scope>test</scope>
             </dependency>
 


### PR DESCRIPTION
According to https://github.com/square/okhttp/issues/3146#issuecomment-569986444 an issue with stale connections that caused SocketTimeoutException errors was fixed in 3.14.5.