### PR TITLE
Disabled connection prompt message when link unfurling is disabled

### DIFF
--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/service/listener/SlackEventHandlerService.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/service/listener/SlackEventHandlerService.java
@@ -185,13 +185,15 @@ public class SlackEventHandlerService {
                 log.debug("Skipping link unfurling for issue {}", key);
                 continue;
             }
-
+            final boolean isProjectAutoConvertEnabled = projectConfigurationManager.isProjectAutoConvertEnabled(issue.getProjectObject());
             // user will get just one invite even if there are multiple issue references in the message
             boolean isUserAllowedToSeeIssue = true;
             if (!isSenderAllowedToSeeIssue(message.getChannelId(), slackUser, issue)) {
                 if (!isInvitationToUserSent && !slackUser.isPresent()) {
-                    inviteUserToConnectToSlack(message, issue);
-                    isInvitationToUserSent = true;
+                    if (isProjectAutoConvertEnabled) {
+                        inviteUserToConnectToSlack(message, issue);
+                        isInvitationToUserSent = true;
+                    }
                 }
                 isUserAllowedToSeeIssue = false;
             }
@@ -215,7 +217,7 @@ public class SlackEventHandlerService {
             if (!message.isMessageEdit() || !previousIssueKeys.contains(key)) {
                 final Optional<DedicatedChannel> dedicatedChannel = dedicatedChannelManager.getDedicatedChannel(issue);
 
-                final boolean isProjectAutoConvertEnabled = projectConfigurationManager.isProjectAutoConvertEnabled(issue.getProjectObject());
+
                 if (isProjectAutoConvertEnabled && !isMutedExternallyShared && isUserAllowedToSeeIssue) {
                     hasFoundAnyIssue = true;
 

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/service/notification/impl/ConfigurationEventRenderer.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/service/notification/impl/ConfigurationEventRenderer.java
@@ -10,7 +10,6 @@ import com.atlassian.jira.plugins.slack.model.event.ProjectMappingConfigurationE
 import com.atlassian.jira.plugins.slack.model.event.UnauthorizedUnfurlEvent;
 import com.atlassian.jira.plugins.slack.service.notification.AttachmentHelper;
 import com.atlassian.jira.plugins.slack.service.notification.NotificationInfo;
-import com.atlassian.jira.project.ProjectManager;
 import com.atlassian.sal.api.message.I18nResolver;
 import com.github.seratch.jslack.api.methods.request.chat.ChatPostMessageRequest;
 import com.github.seratch.jslack.api.methods.request.chat.ChatPostMessageRequest.ChatPostMessageRequestBuilder;
@@ -40,7 +39,6 @@ public class ConfigurationEventRenderer extends AbstractEventRenderer<Configurat
     public ConfigurationEventRenderer(
             final I18nResolver i18nResolver,
             final AttachmentHelper attachmentHelper,
-            final ProjectManager projectManager,
             final IssueManager issueManager) {
         this.i18nResolver = i18nResolver;
         this.attachmentHelper = attachmentHelper;

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/test/java/com/atlassian/jira/plugins/slack/service/listener/SlackEventHandlerServiceTest.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/test/java/com/atlassian/jira/plugins/slack/service/listener/SlackEventHandlerServiceTest.java
@@ -352,6 +352,7 @@ public class SlackEventHandlerServiceTest {
         when(issueManager.getIssueByCurrentKey("ISS-1")).thenReturn(issue1);
         when(issue1.getProjectId()).thenReturn(7L);
         when(issue1.getKey()).thenReturn("K");
+        when(issue1.getProjectObject()).thenReturn(project);
 
         when(taskBuilder.newDirectMessageTask(unauthorizedUnfurlEventArgumentCaptor.capture(), notificationInfoCaptor.capture()))
                 .thenReturn(directMessageTask);
@@ -360,6 +361,7 @@ public class SlackEventHandlerServiceTest {
         when(taskBuilder.newProcessIssueMentionTask(issue1, message)).thenReturn(processIssueMentionTask);
         when(analyticsContextProvider.byTeamIdAndSlackUserId("T", "U")).thenReturn(context);
         when(context.getTeamId()).thenReturn("T");
+        when(projectConfigurationManager.isProjectAutoConvertEnabled(project)).thenReturn(true);
 
         boolean result = target.handleMessage(message);
 


### PR DESCRIPTION
Bot sent the connection prompt message to the user when the link unfurling was disabled. To disable it, i added a check of checkbox value for previews in project settings and globally. 