### PR TITLE
Got rid of "authed_users" mentions in the source code

### DIFF
--- a/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/api/webhooks/AppHomeOpenedSlackEvent.java
+++ b/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/api/webhooks/AppHomeOpenedSlackEvent.java
@@ -9,17 +9,32 @@ import static org.codehaus.jackson.annotate.JsonAutoDetect.Visibility.ANY;
 /*
 https://api.slack.com/events/app_home_opened
 {
-  "token": "XXYYZZ",
-  "team_id": "TXXXXXXXX",
-  "api_app_id": "AXXXXXXXXX",
-  "event": {
     "type": "app_home_opened",
-    "user": "UFXXXXXXX",
-    "channel": "DLX1Z611B"
-  },
-  "type": "event_callback",
-  "event_id": "EvLX1P57NC",
-  "event_time": 1564526855
+    "user": "U061F7AUR",
+    "channel": "D0LAN2Q65",
+    "event_ts": "1515449522000016",
+    "tab": "home",
+    "view": {
+        "id": "VPASKP233",
+        "team_id": "T21312902",
+        "type": "home",
+        "blocks": [
+           ...
+        ],
+        "private_metadata": "",
+        "callback_id": "",
+        "state":{
+            ...
+        },
+        "hash":"1231232323.12321312",
+        "clear_on_close": false,
+        "notify_on_close": false,
+        "root_view_id": "VPASKP233",
+        "app_id": "A21SDS90",
+        "external_id": "",
+        "app_installed_team_id": "T21312902",
+        "bot_id": "BSDKSAO2"
+    }
 }
 */
 @Data

--- a/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/api/webhooks/AppUninstalledSlackEvent.java
+++ b/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/api/webhooks/AppUninstalledSlackEvent.java
@@ -8,15 +8,16 @@ import static org.codehaus.jackson.annotate.JsonAutoDetect.Visibility.ANY;
 /*
 https://api.slack.com/events/app_uninstalled
 {
-    "token": "XXYYZZ",
-    "team_id": "TXXXXXXXX",
-    "api_app_id": "AXXXXXXXXX",
+    "api_app_id": "A00T0R11P66",
     "event": {
+        "event_ts": "1633245770.103223",
         "type": "app_uninstalled"
     },
-    "type": "event_callback",
-    "event_id": "EvXXXXXXXX",
-    "event_time": 1234567890
+    "event_id": "Es36PQNZWHSP",
+    "event_time": 1238349970,
+    "team_id": "TT0EEPP4R",
+    "token": "dr2FDH3al54fFGWEJHsNdo0u",
+    "type": "event_callback"
 }
 */
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/api/webhooks/ChannelArchiveSlackEvent.java
+++ b/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/api/webhooks/ChannelArchiveSlackEvent.java
@@ -8,42 +8,61 @@ import static org.codehaus.jackson.annotate.JsonAutoDetect.Visibility.ANY;
 /*
 https://api.slack.com/events/channel_archive
 {
-    "token": "XXXXXXXXXXXXXYYYYYYYYYYY",
-    "team_id": "TXXXXXXXX",
-    "api_app_id": "AXXXXXXXX",
+    "api_app_id": "A00T0R11P66",
+    "authorizations": [
+        {
+            "enterprise_id": null,
+            "is_bot": true,
+            "is_enterprise_install": false,
+            "team_id": "TT0EEPP4R",
+            "user_id": "U11PIPLPPSM"
+        }
+    ],
     "event": {
-        "type": "channel_archive",
-        "channel": "CGLHJQR8F",
-        "user": "UFXXXXXXX",
-        "is_moved": 0,
-        "event_ts": "1551444460.022100"
+        "channel": "C10P0P00303",
+        "channel_type": "group",
+        "event_ts": "1020050100.110110",
+        "subtype": "channel_archive",
+        "text": "archived the channel",
+        "ts": "1080020003.110010",
+        "type": "message",
+        "user": "U00TPRPIPPA"
     },
-    "type": "event_callback",
-    "event_id": "EvGL0NLP97",
-    "event_time": 1551444460,
-    "authed_users": [
-        "UFXXXXXXX"
-    ]
+    "event_context": "4-tePlwKR8Ne4dy7XjS7QhOSG7dRVkZgVEBsREJDFMDOJcSYDhfGHrIgKDGHTGDbs2KSf4HdKdVxMqQGD4GkVaAgt4KQEtMSGsDn0",
+    "event_id": "Es36PQNZWHSP",
+    "event_time": 1642567283,
+    "is_ext_shared_channel": false,
+    "team_id": "TR6SHGD8R",
+    "token": "dr2FDH3al54fFGWEJHsNdo0u",
+    "type": "event_callback"
 }
 
 https://api.slack.com/events/group_archive
 {
-    "token": "XXXXXXXXXXXXXYYYYYYYYYYY",
-    "team_id": "TXXXXXXXX",
-    "api_app_id": "AXXXXXXXX",
+    "api_app_id": "A55V2K00B66",
+    "authorizations": [
+        {
+            "enterprise_id": null,
+            "is_bot": false,
+            "is_enterprise_install": false,
+            "team_id": "TT0EEPP4R",
+            "user_id": "U44GFKJSDPA"
+        }
+    ],
     "event": {
-        "type": "group_archive",
-        "channel": "GXXXXXXXX",
+        "channel": "C43J4N22303",
+        "event_ts": "1626448873.040100",
         "is_moved": 0,
-        "actor_id": "UFXXXXXXX",
-        "event_ts": "1551444358.000100"
+        "type": "group_archive",
+        "user": "U44GFKJSDPA"
     },
-    "type": "event_callback",
-    "event_id": "EvGLHJCFBL",
-    "event_time": 1551444358,
-    "authed_users": [
-        "UFXXXXXXX"
-    ]
+    "event_context": "4-fdXsgVC3Mv3kl2DsK8GaBNV4aKLxOiSDFcKLFDBMNSFkSDFhhEWcOgKGNBMVHss6VKs5LsVaRrCqJKH3DfNmAdf6KLJaBNCsHa0",
+    "event_id": "Ed56SD99KLJB",
+    "event_time": 1638955773,
+    "is_ext_shared_channel": false,
+    "team_id": "TT0EEPP4R",
+    "token": "dk2JJK2vb87dKLDFGHaTcc7u",
+    "type": "event_callback"
 }
 */
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/api/webhooks/ChannelDeletedSlackEvent.java
+++ b/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/api/webhooks/ChannelDeletedSlackEvent.java
@@ -8,41 +8,57 @@ import static org.codehaus.jackson.annotate.JsonAutoDetect.Visibility.ANY;
 /*
 https://api.slack.com/events/channel_archive
 {
-    "token": "XXXXXXXXXXXXXYYYYYYYYYYY",
-    "team_id": "TXXXXXXXX",
-    "api_app_id": "AXXXXXXXX",
+    "api_app_id": "A66K3L22M66",
+    "authorizations": [
+        {
+            "enterprise_id": null,
+            "is_bot": false,
+            "is_enterprise_install": false,
+            "team_id": "TT0EEPP4R",
+            "user_id": "U11PIPLPPSM"
+        }
+    ],
     "event": {
-        "type": "channel_deleted",
-        "channel": "CGLHJQR8F",
-        "actor_id": "UFXXXXXXX",
-        "event_ts": "1551444515.022700"
+        "actor_id": "U66NBDDLKPA",
+        "channel": "C99DFLK22TY",
+        "event_ts": "1633389585.089700",
+        "type": "channel_deleted"
     },
-    "type": "event_callback",
-    "event_id": "EvGLGA6JE8",
-    "event_time": 1551444515,
-    "authed_users": [
-        "UFXXXXXXX"
-    ]
+    "event_id": "Ee53B8DHG12L",
+    "event_time": 1639276685,
+    "is_ext_shared_channel": false,
+    "team_id": "TT0EEPP4R",
+    "token": "dr2FDH3al54fFGWEJHsNdo0u",
+    "type": "event_callback"
 }
 
 https://api.slack.com/events/group_deleted
 {
-    "token": "XXXXXXXXXXXXXYYYYYYYYYYY",
-    "team_id": "TXXXXXXXX",
-    "api_app_id": "AXXXXXXXX",
+    "api_app_id": "A66K3L22M66",
+    "authorizations": [
+        {
+            "enterprise_id": null,
+            "is_bot": false,
+            "is_enterprise_install": false,
+            "team_id": "TT0EEPP4R",
+            "user_id": "U11PIPLPPSM"
+        }
+    ],
     "event": {
-        "type": "group_deleted",
-        "channel": "GXXXXXXXX",
-        "date_deleted": 1551444591,
-        "actor_id": "UFXXXXXXX",
-        "event_ts": "1551444591.000500"
+        "actor_id": "U11PIPLPPSM",
+        "channel": "C22Q8LK3SL4",
+        "date_deleted": 1619972388,
+        "event_ts": "1638975888.000200",
+        "type": "group_deleted"
     },
-    "type": "event_callback",
-    "event_id": "EvGLT5UN21",
-    "event_time": 1551444591,
-    "authed_users": [
-        "UFXXXXXXX"
-    ]
+
+    "event_context": "4-tePlwKR8Ne4dy7XjS7QhOSG7dRVkZgVEBsREJDFMDOJcSYDhfGHrIgKDGHTGDbs2KSf4HdKdVxMqQGD4GkVaAgt4KQEtMSGsDn02Ukw0IilkjW1kSDF6MNBzODk3McZ87H0",
+    "event_id": "Es36PQNZWHSP",
+    "event_time": 1622937888,
+    "is_ext_shared_channel": false,
+    "team_id": "TT0EEPP4R",
+    "token": "dr2FDH3al54fFGWEJHsNdo0u",
+    "type": "event_callback"
 }
 */
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/api/webhooks/ChannelUnarchiveSlackEvent.java
+++ b/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/api/webhooks/ChannelUnarchiveSlackEvent.java
@@ -8,40 +8,60 @@ import static org.codehaus.jackson.annotate.JsonAutoDetect.Visibility.ANY;
 /*
 https://api.slack.com/events/channel_unarchive
 {
-    "token": "XXXXXXXXXXXXXYYYYYYYYYYY",
-    "team_id": "TXXXXXXXX",
-    "api_app_id": "AXXXXXXXX",
+    "api_app_id": "A00T0R11P66",
+    "authorizations": [
+        {
+            "enterprise_id": null,
+            "is_bot": true,
+            "is_enterprise_install": false,
+            "team_id": "TT0EEPP4R",
+            "user_id": "U11PIPLPPSM"
+        }
+    ],
     "event": {
-        "type": "channel_unarchive",
-        "channel": "CGLHJQR8F",
-        "user": "UFXXXXXXX",
-        "event_ts": "1551444306.021500"
+        "channel": "C10P0P00303",
+        "channel_type": "group",
+        "event_ts": "1020050100.110160",
+        "subtype": "channel_unarchive",
+        "text": "un-archived the channel",
+        "ts": "1080020003.110120",
+        "type": "message",
+        "user": "U00TPRPIPPA"
     },
-    "type": "event_callback",
-    "event_id": "EvGL0LSRMF",
-    "event_time": 1551444306,
-    "authed_users": [
-        "UFXXXXXXX"
-    ]
+    "event_context": "4-tePlwKR8Ne2dy7XjS7QhOSG7dRVkZgVEBsKSHDNVBCJcSYDhfGHrIgKLSMNMSbs2KSf4HdKdVxMqPGD4GkVaAgt4KQEtMSGsDn0",
+    "event_id": "Es89PQNRWHSP",
+    "event_time": 1638964093,
+    "is_ext_shared_channel": false,
+    "team_id": "TR6SHGD8R",
+    "token": "dr2FDH3al54fFGWEJHsNdo0u",
+    "type": "event_callback"
 }
 
 https://api.slack.com/events/group_unarchive
 {
-    "token": "XXXXXXXXXXXXXYYYYYYYYYYY",
-    "team_id": "TXXXXXXXX",
-    "api_app_id": "AG5P6LKFZ",
+    "api_app_id": "A55V2K00B66",
+    "authorizations": [
+        {
+            "enterprise_id": null,
+            "is_bot": false,
+            "is_enterprise_install": false,
+            "team_id": "TT0EEPP4R",
+            "user_id": "U44GFKJSDPA"
+        }
+    ],
     "event": {
+        "channel": "C43J4N22303",
+        "event_ts": "1626448873.013000",
         "type": "group_unarchive",
-        "channel": "GXXXXXXXX",
-        "actor_id": "UFXXXXXXX",
-        "event_ts": "1551444418.000300"
+        "user": "U44GFKJSDPA"
     },
-    "type": "event_callback",
-    "event_id": "EvGL0N5Y0Z",
-    "event_time": 1551444418,
-    "authed_users": [
-        "UFXXXXXXX"
-    ]
+    "event_context": "4-fdXsgVC3Mv3kl2DsHBbb3NV4aJK78fSDFcKLFDBMNSFkSDFhhEWcOgKGNBMVHshh6FO5LsVaRrCqY7IokfNmAdf6KLJaBNCsHa0",
+    "event_id": "Ed56SD99KLJB",
+    "event_time": 1638964093,
+    "is_ext_shared_channel": false,
+    "team_id": "TT0EEPP4R",
+    "token": "dk2JJK2vb87dKLDFGHaTcc7u",
+    "type": "event_callback"
 }
 */
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/api/webhooks/GenericMessageSlackEvent.java
+++ b/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/api/webhooks/GenericMessageSlackEvent.java
@@ -16,142 +16,51 @@ https://api.slack.com/events/message.im
 https://api.slack.com/events/message.groups
 https://api.slack.com/events/message.channels
 {
-  "token": "XXXXXXXXXXXXYYYYYYYYYYYY",
-  "team_id": "TXXXXXXXX",
-  "api_app_id": "AXXXXXXXX",
-  "event": {
-    "client_msg_id": "853ce7b3-b7ff-4096-b202-c3bbf65c1e4a",
-    "type": "message",
-    "text": "Any message",
-    "user": "UC7LU9ZGS",
-    "ts": "1547500911.010000",
-    "channel": "CF49QEJF4",
-    "event_ts": "1547500911.010000",
-    "channel_type": "channel"
-  },
-  "type": "event_callback",
-  "event_id": "EvFDLP0K7F",
-  "event_time": 1547500911,
-  "authed_users": [
-    "UF36K27BR"
-  ]
-}
-
-{
-  "token": "XXXXXXXXXXXXYYYYYYYYYYYY",
-  "team_id": "TXXXXXXXX",
-  "api_app_id": "AXXXXXXXX",
-  "event": {
-    "type": "message",
-    "deleted_ts": "1547500911.010000",
-    "subtype": "message_deleted",
-    "hidden": true,
-    "channel": "CF49QEJF4",
-    "previous_message": {
-      "type": "message",
-      "user": "UC7LU9ZGS",
-      "text": "Any message",
-      "client_msg_id": "853ce7b3-b7ff-4096-b202-c3bbf65c1e4a",
-      "ts": "1547500911.010000"
+    "api_app_id": "A00T0R11P66",
+    "authorizations": [
+        {
+            "enterprise_id": null,
+            "is_bot": true,
+            "is_enterprise_install": false,
+            "team_id": "TT0EEPP4R",
+            "user_id": "U11PIPLPPSM"
+        }
+    ],
+    "event": {
+        "blocks": [
+            {
+                "block_id": "HeN",
+                "elements": [
+                    {
+                        "elements": [
+                            {
+                                "text": "hello",
+                                "type": "text"
+                            }
+                        ],
+                        "type": "rich_text_section"
+                    }
+                ],
+                "type": "rich_text"
+            }
+        ],
+        "channel": "C10P0P00303",
+        "channel_type": "group",
+        "client_msg_id": "fkj3b7s5-2w33-6n78-d33a-b7782s3v62s0",
+        "event_ts": "1638793296.000200",
+        "team": "TT0EEPP4R",
+        "text": "hello",
+        "ts": "1548324796.000200",
+        "type": "message",
+        "user": "U00TPRPIPPA"
     },
-    "event_ts": "1547500951.010100",
-    "ts": "1547500951.010100",
-    "channel_type": "channel"
-  },
-  "type": "event_callback",
-  "event_id": "EvFDLPHL69",
-  "event_time": 1547500951,
-  "authed_users": [
-    "UF36K27BR"
-  ]
-}
-
-{
-  "token": "XXXXXXXXXXXXYYYYYYYYYYYY",
-  "team_id": "TXXXXXXXX",
-  "api_app_id": "AXXXXXXXX",
-  "event": {
-    "type": "message",
-    "message": {
-      "type": "message",
-      "user": "UC7SRSBH7",
-      "text": "PT-2 hahahahahaha db dfvbdffvdfvdfva ad asd",
-      "client_msg_id": "dad77307-b142-462b-85b6-e9f0b0a6dc34",
-      "edited": {
-        "user": "UC7SRSBH7",
-        "ts": "1546645882.000000"
-      },
-      "ts": "1546645707.005000"
-    },
-    "subtype": "message_changed",
-    "hidden": true,
-    "channel": "CF62ZFGFM",
-    "previous_message": {
-      "type": "message",
-      "user": "UC7SRSBH7",
-      "text": "PT-2 hahahahahaha db dfvbdffvdfvdfv",
-      "client_msg_id": "dad77307-b142-462b-85b6-e9f0b0a6dc34",
-      "edited": {
-        "user": "UC7SRSBH7",
-        "ts": "1546645740.000000"
-      },
-      "ts": "1546645707.005000"
-    },
-    "event_ts": "1546645882.005600",
-    "ts": "1546645882.005600",
-    "channel_type": "channel"
-  },
-  "type": "event_callback",
-  "event_id": "EvF6E3KFKK",
-  "event_time": 1546645882,
-  "authed_users": [
-    "UF62SGQP6"
-  ]
-}
-
-
-{
-  "token": "XXXXXXXXXXXXYYYYYYYYYYYY",
-  "team_id": "TXXXXXXXX",
-  "api_app_id": "AXXXXXXXX",
-  "event": {
-    "type": "message",
-    "text": "You have been removed from #testcreate2 by <@UC7SRSBH7>",
-    "user": "USLACKBOT",
-    "ts": "1547268549.000100",
-    "channel": "DF6DMV4KX",
-    "event_ts": "1547268549.000100",
-    "channel_type": "im"
-  },
-  "type": "event_callback",
-  "event_id": "EvFBDY20JC",
-  "event_time": 1547268549,
-  "authed_users": [
-    "UF62SGQP6"
-  ]
-}
-
-{
-  "token": "XXXXXXXXXXXXYYYYYYYYYYYY",
-  "team_id": "TXXXXXXXX",
-  "api_app_id": "AXXXXXXXX",
-  "event": {
-    "user": "UF62SGQP6",
-    "type": "message",
-    "subtype": "channel_join",
-    "ts": "1547268640.003100",
-    "text": "<@UF62SGQP6> has joined the channel",
-    "inviter": "UC7SRSBH7",
-    "channel": "CF662G3JN",
-    "event_ts": "1547268640.003100",
-    "channel_type": "channel"
-  },
-  "type": "event_callback",
-  "event_id": "EvFCC4SBGV",
-  "event_time": 1547268640,
-  "authed_users": [
-    "UF62SGQP6"
-  ]
+    "event_context": "4-tePlwKR8Ne4dy7XjS7QhWQL7dRVkZgVEBsREJNBMDOJcSYDhfGHrIgKDGHTGDbs2KSf4HdKdVxMqQGD4GkVaAgt4KQEtMSGsDn0",
+    "event_id": "Es36PQNZWHSP",
+    "event_time": 1634653566,
+    "is_ext_shared_channel": false,
+    "team_id": "TT0EEPP4R",
+    "token": "dr2FDH3al54fFGWEJHsNdo0u",
+    "type": "event_callback"
 }
 */
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/api/webhooks/LinkSharedSlackEvent.java
+++ b/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/api/webhooks/LinkSharedSlackEvent.java
@@ -13,45 +13,33 @@ https://api.slack.com/events/link_shared
     "authorizations": [
         {
             "enterprise_id": null,
-            "is_bot": true,
+            "is_bot": false,
             "is_enterprise_install": false,
             "team_id": "TT0EEPP4R",
             "user_id": "U11PIPLPPSM"
         }
     ],
     "event": {
-        "blocks": [
+        "channel": "C10P0P00303",
+        "event_ts": "1638793296.000200",
+        "is_bot_user_member": false,
+        "links": [
             {
-                "block_id": "+sY",
-                "elements": [
-                    {
-                        "elements": [
-                            {
-                                "type": "link",
-                                "url": "https://www.youtube.com/watch?v=xIOjqTRYZwg"
-                            }
-                        ],
-                        "type": "rich_text_section"
-                    }
-                ],
-                "type": "rich_text"
+                "domain": "domain.com",
+                "url": "https://domain.com"
             }
         ],
-        "channel": "C10P0P00303",
-        "channel_type": "group",
-        "client_msg_id": "fkj3b7s5-2w33-6n78-d33a-b7782s3v62s0",
-        "event_ts": "1637673397.000700",
-        "team": "TT0EEPP4R",
-        "text": "<https://www.youtube.com/watch?v=xIOjqTRYZwg>",
-        "ts": "1988231397.000700",
-        "type": "message",
+        "message_ts": "U77HGNBMCLD-fgvh99ae-f8sd-899c-21bv-3kjlmn44l67g2-9nb33d7kjm0cd3e8796f324jhh4f37f7898796432klj1c324561234d73c6563f",
+        "source": "source",
+        "type": "link_shared",
+        "unfurl_id": "U77HGNBMCLD-fgvh99ae-f8sd-899c-21bv-3kjlmn44l67g2-9nb33d7kjm0cd3e8796f324jhh4f37f7898796432klj1c324561234d73c653f",
         "user": "U00TPRPIPPA"
     },
     "event_context": "4-tePlwKR8Ne4dy7XjS7QhWQL7dRVkZgVEBsREJNBMDOJcSYDhfGHrIgKDGHTGDbs2KSf4HdKdVxMqQGD4GkVaAgt4KQEtMSGsDn0",
     "event_id": "Es36PQNZWHSP",
-    "event_time": 1465987397,
+    "event_time": 1639051134,
     "is_ext_shared_channel": false,
-    "team_id": "TT0EEPP4R",
+     "team_id": "TT0EEPP4R",
     "token": "dr2FDH3al54fFGWEJHsNdo0u",
     "type": "event_callback"
 }

--- a/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/api/webhooks/LinkSharedSlackEvent.java
+++ b/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/api/webhooks/LinkSharedSlackEvent.java
@@ -9,37 +9,51 @@ import java.util.List;
 /*
 https://api.slack.com/events/link_shared
 {
-    "token": "XXYYZZ",
-    "team_id": "TXXXXXXXX",
-    "api_app_id": "AXXXXXXXXX",
-    "event": {
-        "type": "link_shared",
-        "channel": "Cxxxxxx",
-        "user": "Uxxxxxxx",
-        "message_ts": "123456789.9875",
-        "thread_ts": "123456621.1855",
-        "links": [
-            {
-                "domain": "example.com",
-                "url": "https://example.com/12345"
-            },
-            {
-                "domain": "example.com",
-                "url": "https://example.com/67890"
-            },
-            {
-                "domain": "another-example.com",
-                "url": "https://yet.another-example.com/v/abcde"
-            }
-        ]
-    },
-    "type": "event_callback",
-    "authed_users": [
-        "UXXXXXXX1",
-        "UXXXXXXX2"
+    "api_app_id": "A00T0R11P66",
+    "authorizations": [
+        {
+            "enterprise_id": null,
+            "is_bot": true,
+            "is_enterprise_install": false,
+            "team_id": "TT0EEPP4R",
+            "user_id": "U11PIPLPPSM"
+        }
     ],
-    "event_id": "Ev08MFMKH6",
-    "event_time": 123456789
+    "event": {
+        "blocks": [
+            {
+                "block_id": "+sY",
+                "elements": [
+                    {
+                        "elements": [
+                            {
+                                "type": "link",
+                                "url": "https://www.youtube.com/watch?v=xIOjqTRYZwg"
+                            }
+                        ],
+                        "type": "rich_text_section"
+                    }
+                ],
+                "type": "rich_text"
+            }
+        ],
+        "channel": "C10P0P00303",
+        "channel_type": "group",
+        "client_msg_id": "fkj3b7s5-2w33-6n78-d33a-b7782s3v62s0",
+        "event_ts": "1637673397.000700",
+        "team": "TT0EEPP4R",
+        "text": "<https://www.youtube.com/watch?v=xIOjqTRYZwg>",
+        "ts": "1988231397.000700",
+        "type": "message",
+        "user": "U00TPRPIPPA"
+    },
+    "event_context": "4-tePlwKR8Ne4dy7XjS7QhWQL7dRVkZgVEBsREJNBMDOJcSYDhfGHrIgKDGHTGDbs2KSf4HdKdVxMqQGD4GkVaAgt4KQEtMSGsDn0",
+    "event_id": "Es36PQNZWHSP",
+    "event_time": 1465987397,
+    "is_ext_shared_channel": false,
+    "team_id": "TT0EEPP4R",
+    "token": "dr2FDH3al54fFGWEJHsNdo0u",
+    "type": "event_callback"
 }
 */
 @Data

--- a/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/api/webhooks/MemberJoinedChannelSlackEvent.java
+++ b/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/api/webhooks/MemberJoinedChannelSlackEvent.java
@@ -9,24 +9,32 @@ import static org.codehaus.jackson.annotate.JsonAutoDetect.Visibility.ANY;
 /*
 https://api.slack.com/events/member_joined_channel
 {
-  "token": "PfadpmYMrCxnqUH0tMl8Fryx",
-  "team_id": "TC7SRSB25",
-  "api_app_id": "AF7KED0HL",
-  "event": {
-    "type": "member_joined_channel",
-    "user": "UF62SGQP6",
-    "channel": "CF662G3JN",
-    "channel_type": "C",
-    "team": "TC7SRSB25",
-    "inviter": "UC7SRSBH7",
-    "event_ts": "1547268640.003000"
-  },
-  "type": "event_callback",
-  "event_id": "EvFCC4SB3P",
-  "event_time": 1547268640,
-  "authed_users": [
-    "UF62SGQP6"
-  ]
+    "api_app_id": "A00T0R11P66",
+    "authorizations": [
+        {
+            "enterprise_id": null,
+            "is_bot": true,
+            "is_enterprise_install": false,
+            "team_id": "TT0EEPP4R",
+            "user_id": "U11PIPLPPSM"
+        }
+    ],
+    "event": {
+        "channel": "C10P0P00303",
+        "channel_type": "C",
+        "event_ts": "1638793296.000200",
+        "inviter": "U32NBSDOPPA",
+        "team": "TT0EEPP4R",
+        "type": "member_joined_channel",
+        "user": "U00TPRPIPPA"
+    },
+    "event_context": "4-tePlwKR8Ne4dy7XjS7QhWQL7dRVkZgVEBsREJNBMDOJcSYDhfGHrIgKDGHTGDbs2KSf4HdKdVxMqQGD4GkVaAgt4KQEtMSGsDn0iQzAyNBMVCzSDF6NifQ",
+    "event_id": "Es36PQNZWHSP",
+    "event_time": 1634653566,
+    "is_ext_shared_channel": false,
+    "team_id": "TT0EEPP4R",
+    "token": "dr2FDH3al54fFGWEJHsNdo0u",
+    "type": "event_callback"
 }
 */
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/api/webhooks/SlackSlashCommand.java
+++ b/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/api/webhooks/SlackSlashCommand.java
@@ -6,19 +6,19 @@ import lombok.experimental.NonFinal;
 
 /*
 https://api.slack.com/slash-commands
-token=gIkuvaNzQIHg97ATvDxqgjtO
-&team_id=T0001
-&team_domain=example
-&enterprise_id=E0001
-&enterprise_name=Globular%20Construct%20Inc
-&channel_id=C2147483705
-&channel_name=test
-&user_id=U2147483697
-&user_name=Steve
-&command=/weather
-&text=94070
-&response_url=https://hooks.slack.com/commands/1234/5678
-&trigger_id=13345224609.738474920.8088930838d88f008e0
+token:                 dr7HGN2lp78sLKMNBVfEsd0u
+team_id:               TT0EEPP4R
+team_domain:           domain
+channel_id:            C10P0P00303
+channel_name:          name-channel
+user_id:               U11PIPLPPSM
+user_name:             username
+command:               /commane
+text:
+api_app_id:            A00T0R11P66
+is_enterprise_install: false
+response_url:          https://hooks.slack.com/commands/TC3NTTN4R/2839125455296/L0Tb3Bh7qvoVQECQt3jEQ3TE
+trigger_id:            2768768122361.413245683425.c7h9k2vd47xl478df2sa4kf333lkj193
 */
 @Value
 @NonFinal

--- a/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/api/webhooks/TokensRevokedSlackEvent.java
+++ b/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/api/webhooks/TokensRevokedSlackEvent.java
@@ -12,23 +12,24 @@ import static org.codehaus.jackson.annotate.JsonAutoDetect.Visibility.ANY;
 /*
 https://api.slack.com/events/tokens_revoked
 {
-    "token": "XXYYZZ",
-    "team_id": "TXXXXXXXX",
-    "api_app_id": "AXXXXXXXXX",
+    "api_app_id": "A00T0R11P66",
     "event": {
-        "type": "tokens_revoked",
+        "event_ts": "1633245770.103223",
         "tokens": {
-            "oauth": [
-                "UXXXXXXXX"
-            ],
             "bot": [
-                "UXXXXXXXX"
+                "U77KMNSACCM"
+            ],
+            "oauth": [
+                "U22JHNBLDNF"
             ]
-        }
+        },
+        "type": "tokens_revoked"
     },
-    "type": "event_callback",
-    "event_id": "EvXXXXXXXX",
-    "event_time": 1234567890
+    "event_id": "Es36PQNZWHSP",
+    "event_time": 1238349970,
+    "team_id": "TT0EEPP4R",
+    "token": "dr2FDH3al54fFGWEJHsNdo0u",
+    "type": "event_callback"
 }
 */
 @JsonIgnoreProperties(ignoreUnknown = true)


### PR DESCRIPTION
I updated samples of Slack webhooks payloads using mitmproxy and got rid of "authed_users" mentions in the source code