### PR TITLE
Added handling for channels in different workspaces that share the same ID

### DIFF
--- a/bitbucket-slack-server-integration-plugin/src/main/java/com/atlassian/bitbucket/plugins/slack/listener/SlackChannelEventListener.java
+++ b/bitbucket-slack-server-integration-plugin/src/main/java/com/atlassian/bitbucket/plugins/slack/listener/SlackChannelEventListener.java
@@ -14,11 +14,9 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 @Service
 public class SlackChannelEventListener {
@@ -70,11 +68,7 @@ public class SlackChannelEventListener {
             final List<ConversationKey> mutedChannelIds = settingService.getMutedChannelIds();
             if (!mutedChannelIds.isEmpty()) {
                 Set<ConversationKey> activeConversationIds = event.getConversations().stream()
-                        .flatMap(c -> {
-                            List<ConversationKey> list = new ArrayList<>();
-                            c.getSharedTeamIds().forEach(t -> list.add(new ConversationKey(t, c.getId())));
-                            return list.stream();
-                        })
+                        .map(c -> new ConversationKey(event.getTeamId(), c.getId()))
                         .collect(Collectors.toSet());
                 mutedChannelIds.stream()
                         .filter(activeConversationIds::contains)

--- a/bitbucket-slack-server-integration-plugin/src/main/java/com/atlassian/bitbucket/plugins/slack/listener/SlackChannelEventListener.java
+++ b/bitbucket-slack-server-integration-plugin/src/main/java/com/atlassian/bitbucket/plugins/slack/listener/SlackChannelEventListener.java
@@ -2,6 +2,7 @@ package com.atlassian.bitbucket.plugins.slack.listener;
 
 import com.atlassian.bitbucket.plugins.slack.notification.configuration.NotificationConfigurationService;
 import com.atlassian.event.api.EventListener;
+import com.atlassian.plugins.slack.api.ConversationKey;
 import com.atlassian.plugins.slack.api.events.SlackConversationsLoadedEvent;
 import com.atlassian.plugins.slack.api.webhooks.ChannelArchiveSlackEvent;
 import com.atlassian.plugins.slack.api.webhooks.ChannelDeletedSlackEvent;
@@ -38,22 +39,25 @@ public class SlackChannelEventListener {
     @EventListener
     public void onChannelArchivedEvent(final ChannelArchiveSlackEvent event) {
         final String channelId = event.getChannel();
-        asyncExecutor.run(() -> settingService.muteChannel(channelId));
+        final String teamId = event.getSlackEvent().getTeamId();
+        asyncExecutor.run(() -> settingService.muteChannel(new ConversationKey(teamId, channelId)));
     }
 
     @EventListener
     public void onChannelUnarchivedEvent(final ChannelUnarchiveSlackEvent event) {
         final String channelId = event.getChannel();
-        asyncExecutor.run(() -> settingService.unmuteChannel(channelId));
+        final String teamId = event.getSlackEvent().getTeamId();
+        asyncExecutor.run(() -> settingService.unmuteChannel(new ConversationKey(teamId, channelId)));
     }
 
     @EventListener
     public void onChannelDeletedEvent(final ChannelDeletedSlackEvent event) {
         final String channelId = event.getChannel();
+        final String teamId = event.getSlackEvent().getTeamId();
         asyncExecutor.run(() -> {
             LOGGER.debug("Removing notification mapping for channel {} because the channel was deleted", channelId);
             notificationService.removeNotificationsForChannel(channelId);
-            settingService.unmuteChannel(channelId);
+            settingService.unmuteChannel(new ConversationKey(teamId, channelId));
         });
     }
 
@@ -62,7 +66,7 @@ public class SlackChannelEventListener {
         // unmute channel if they are returned in the list of active channels;
         // just in case we missed 'channel_unarchive' event
         asyncExecutor.run(() -> {
-            final List<String> mutedChannelIds = settingService.getMutedChannelIds();
+            final List<ConversationKey> mutedChannelIds = settingService.getMutedChannelIds();
             if (!mutedChannelIds.isEmpty()) {
                 Set<String> activeConversationIds = event.getConversations().stream()
                         .map(Conversation::getId)

--- a/bitbucket-slack-server-integration-plugin/src/main/java/com/atlassian/bitbucket/plugins/slack/notification/configuration/DefaultNotificationConfigurationService.java
+++ b/bitbucket-slack-server-integration-plugin/src/main/java/com/atlassian/bitbucket/plugins/slack/notification/configuration/DefaultNotificationConfigurationService.java
@@ -14,6 +14,7 @@ import com.atlassian.event.api.EventListener;
 import com.atlassian.event.api.EventPublisher;
 import com.atlassian.plugins.slack.analytics.AnalyticsContext;
 import com.atlassian.plugins.slack.analytics.AnalyticsContextProvider;
+import com.atlassian.plugins.slack.api.ConversationKey;
 import com.atlassian.plugins.slack.api.notification.ChannelToNotify;
 import com.atlassian.plugins.slack.settings.SlackSettingService;
 import lombok.RequiredArgsConstructor;
@@ -82,7 +83,7 @@ public class DefaultNotificationConfigurationService implements NotificationConf
     public Set<ChannelToNotify> getChannelsToNotify(@Nonnull NotificationSearchRequest request) {
         Set<ChannelToNotify> channels = dao.getChannelsToNotify(request);
         Set<ChannelToNotify> unmutedChannels = channels.stream()
-                .filter(channel -> !settingService.isChannelMuted(channel.getChannelId()))
+                .filter(channel -> !settingService.isChannelMuted(new ConversationKey(channel.getTeamId(), channel.getChannelId())))
                 .collect(Collectors.toSet());
         return unmutedChannels;
     }

--- a/bitbucket-slack-server-integration-plugin/src/main/java/com/atlassian/bitbucket/plugins/slack/notification/configuration/dao/AoNotificationConfigurationDao.java
+++ b/bitbucket-slack-server-integration-plugin/src/main/java/com/atlassian/bitbucket/plugins/slack/notification/configuration/dao/AoNotificationConfigurationDao.java
@@ -206,7 +206,7 @@ public class AoNotificationConfigurationDao extends AbstractAoDao implements Not
                     DefaultRepositoryConfiguration.Builder builder = new DefaultRepositoryConfiguration.Builder(repo);
                     entry.getValue()
                             .forEach(aoConfig -> {
-                                final Optional<Conversation> conversation = conversationsAndLinks.conversation(aoConfig.getChannelId());
+                                final Optional<Conversation> conversation = conversationsAndLinks.conversation(new ConversationKey(aoConfig.getTeamId(), aoConfig.getChannelId()));
                                 final Optional<SlackLink> slackLink = conversationsAndLinks.link(aoConfig.getTeamId());
                                 Verbosity verbosity = bitbucketSlackSettingsService.getVerbosity(repo.getId(),
                                         aoConfig.getTeamId(), aoConfig.getChannelId());

--- a/bitbucket-slack-server-integration-plugin/src/test/java/com/atlassian/bitbucket/plugins/slack/listener/SlackChannelEventListenerTest.java
+++ b/bitbucket-slack-server-integration-plugin/src/test/java/com/atlassian/bitbucket/plugins/slack/listener/SlackChannelEventListenerTest.java
@@ -96,8 +96,8 @@ public class SlackChannelEventListenerTest {
         List<Conversation> conversations = Collections.singletonList(conversation);
         List<ConversationKey> mutedConversations = Arrays.asList(new ConversationKey(TEAM_ID, CHANNEL_ID));
         when(conversation.getId()).thenReturn(CHANNEL_ID);
-        when(conversation.getSharedTeamIds()).thenReturn(Arrays.asList(TEAM_ID, "other TEAM_ID"));
         when(settingService.getMutedChannelIds()).thenReturn(mutedConversations);
+        when(slackConversationsLoadedEvent.getTeamId()).thenReturn(TEAM_ID);
         when(slackConversationsLoadedEvent.getConversations()).thenReturn(conversations);
 
         target.onConversationsLoadedEvent(slackConversationsLoadedEvent);

--- a/bitbucket-slack-server-integration-plugin/src/test/java/com/atlassian/bitbucket/plugins/slack/listener/SlackChannelEventListenerTest.java
+++ b/bitbucket-slack-server-integration-plugin/src/test/java/com/atlassian/bitbucket/plugins/slack/listener/SlackChannelEventListenerTest.java
@@ -1,10 +1,12 @@
 package com.atlassian.bitbucket.plugins.slack.listener;
 
 import com.atlassian.bitbucket.plugins.slack.notification.configuration.NotificationConfigurationService;
+import com.atlassian.plugins.slack.api.ConversationKey;
 import com.atlassian.plugins.slack.api.events.SlackConversationsLoadedEvent;
 import com.atlassian.plugins.slack.api.webhooks.ChannelArchiveSlackEvent;
 import com.atlassian.plugins.slack.api.webhooks.ChannelDeletedSlackEvent;
 import com.atlassian.plugins.slack.api.webhooks.ChannelUnarchiveSlackEvent;
+import com.atlassian.plugins.slack.api.webhooks.SlackEvent;
 import com.atlassian.plugins.slack.settings.SlackSettingService;
 import com.atlassian.plugins.slack.test.util.CommonTestUtil;
 import com.atlassian.plugins.slack.util.AsyncExecutor;
@@ -25,7 +27,9 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class SlackChannelEventListenerTest {
+    private static final String TEAM_ID = "T";
     private static final String CHANNEL_ID = "C";
+
     @Mock
     private SlackSettingService settingService;
     @Mock
@@ -42,6 +46,8 @@ public class SlackChannelEventListenerTest {
     private Conversation conversation;
     @Mock
     private AsyncExecutor asyncExecutor;
+    @Mock
+    private SlackEvent slackEvent;
 
     @InjectMocks
     private SlackChannelEventListener target;
@@ -54,41 +60,48 @@ public class SlackChannelEventListenerTest {
     @Test
     public void onChannelArchivedEvent_shouldCallExpectedMethods() {
         when(channelArchiveSlackEvent.getChannel()).thenReturn(CHANNEL_ID);
+        when(channelArchiveSlackEvent.getSlackEvent()).thenReturn(slackEvent);
+        when(slackEvent.getTeamId()).thenReturn(TEAM_ID);
 
         target.onChannelArchivedEvent(channelArchiveSlackEvent);
 
-        verify(settingService).muteChannel(CHANNEL_ID);
+        verify(settingService).muteChannel(new ConversationKey(TEAM_ID, CHANNEL_ID));
     }
 
     @Test
     public void onChannelUnarchivedEvent_shouldCallExpectedMethods() {
         when(channelUnarchiveSlackEvent.getChannel()).thenReturn(CHANNEL_ID);
+        when(channelUnarchiveSlackEvent.getSlackEvent()).thenReturn(slackEvent);
+        when(slackEvent.getTeamId()).thenReturn(TEAM_ID);
 
         target.onChannelUnarchivedEvent(channelUnarchiveSlackEvent);
 
-        verify(settingService).unmuteChannel(CHANNEL_ID);
+        verify(settingService).unmuteChannel(new ConversationKey(TEAM_ID, CHANNEL_ID));
     }
 
     @Test
     public void onChannelDeletedEvent_shouldCallExpectedMethods() {
         when(channelDeletedSlackEvent.getChannel()).thenReturn(CHANNEL_ID);
+        when(channelDeletedSlackEvent.getSlackEvent()).thenReturn(slackEvent);
+        when(slackEvent.getTeamId()).thenReturn(TEAM_ID);
 
         target.onChannelDeletedEvent(channelDeletedSlackEvent);
 
         verify(notificationService).removeNotificationsForChannel(CHANNEL_ID);
-        verify(settingService).unmuteChannel(CHANNEL_ID);
+        verify(settingService).unmuteChannel(new ConversationKey(TEAM_ID, CHANNEL_ID));
     }
 
     @Test
     public void onConversationsLoadedEvent_shouldCallExpectedMethods() {
         List<Conversation> conversations = Collections.singletonList(conversation);
-        List<String> conversationsStr = Arrays.asList(CHANNEL_ID, "X");
+        List<ConversationKey> mutedConversations = Arrays.asList(new ConversationKey(TEAM_ID, CHANNEL_ID));
         when(conversation.getId()).thenReturn(CHANNEL_ID);
-        when(settingService.getMutedChannelIds()).thenReturn(conversationsStr);
+        when(conversation.getSharedTeamIds()).thenReturn(Arrays.asList(TEAM_ID, "other TEAM_ID"));
+        when(settingService.getMutedChannelIds()).thenReturn(mutedConversations);
         when(slackConversationsLoadedEvent.getConversations()).thenReturn(conversations);
 
         target.onConversationsLoadedEvent(slackConversationsLoadedEvent);
 
-        verify(settingService).unmuteChannel(CHANNEL_ID);
+        verify(settingService).unmuteChannel(new ConversationKey(TEAM_ID, CHANNEL_ID));
     }
 }

--- a/bitbucket-slack-server-integration-plugin/src/test/java/com/atlassian/bitbucket/plugins/slack/notification/configuration/dao/AoNotificationConfigurationDaoTest.java
+++ b/bitbucket-slack-server-integration-plugin/src/test/java/com/atlassian/bitbucket/plugins/slack/notification/configuration/dao/AoNotificationConfigurationDaoTest.java
@@ -15,6 +15,7 @@ import com.atlassian.bitbucket.project.Project;
 import com.atlassian.bitbucket.repository.Repository;
 import com.atlassian.bitbucket.repository.RepositoryService;
 import com.atlassian.bitbucket.util.PageRequestImpl;
+import com.atlassian.plugins.slack.api.ConversationKey;
 import com.atlassian.plugins.slack.api.SlackLink;
 import com.atlassian.plugins.slack.api.client.ConversationLoaderHelper;
 import com.atlassian.plugins.slack.api.client.ConversationsAndLinks;
@@ -223,7 +224,7 @@ public class AoNotificationConfigurationDaoTest extends AbstractAoDaoTest {
                 AoNotificationConfiguration.CHANNEL_ID_COLUMN, CHANNEL_ID
         ));
         when(conversationLoaderHelper.conversationsAndLinksById(any(), any(), any())).thenReturn(conversationsAndLinks);
-        when(conversationsAndLinks.conversation(CHANNEL_ID)).thenReturn(Optional.of(conversation));
+        when(conversationsAndLinks.conversation(new ConversationKey(TEAM_ID, CHANNEL_ID))).thenReturn(Optional.of(conversation));
         when(conversation.getName()).thenReturn("someConversationName");
         when(conversationsAndLinks.link(TEAM_ID)).thenReturn(Optional.of(slackLink));
         when(repositoryService.getById(REPO_ID)).thenReturn(repository);

--- a/confluence-slack-server-integration-plugin/src/main/java/com/atlassian/confluence/plugins/slack/spacetochannel/configuration/SpaceToChannelConfiguration.java
+++ b/confluence-slack-server-integration-plugin/src/main/java/com/atlassian/confluence/plugins/slack/spacetochannel/configuration/SpaceToChannelConfiguration.java
@@ -115,14 +115,14 @@ public class SpaceToChannelConfiguration {
         /**
          * This will return an existing SpaceToChannelSettings.Builder for the channelId, or create a new one.
          *
-         * @param channelId the channel id the SpaceToChannelSettings.Builder is for
+         * @param conversationKey the channel id the SpaceToChannelSettings.Builder is for
          * @return a SpaceToChannelSettings.Builder
          */
-        public SpaceToChannelSettings.Builder getSettingsBuilder(ConversationKey channelId) {
-            SpaceToChannelSettings.Builder builder = channelSettingBuilders.get(channelId);
+        public SpaceToChannelSettings.Builder getSettingsBuilder(ConversationKey conversationKey) {
+            SpaceToChannelSettings.Builder builder = channelSettingBuilders.get(conversationKey);
             if (builder == null) {
                 builder = new SpaceToChannelSettings.Builder();
-                channelSettingBuilders.put(channelId, builder);
+                channelSettingBuilders.put(conversationKey, builder);
             }
 
             return builder;

--- a/confluence-slack-server-integration-plugin/src/main/java/com/atlassian/confluence/plugins/slack/spacetochannel/configuration/SpaceToChannelConfiguration.java
+++ b/confluence-slack-server-integration-plugin/src/main/java/com/atlassian/confluence/plugins/slack/spacetochannel/configuration/SpaceToChannelConfiguration.java
@@ -1,6 +1,7 @@
 package com.atlassian.confluence.plugins.slack.spacetochannel.configuration;
 
 import com.atlassian.confluence.spaces.Space;
+import com.atlassian.plugins.slack.api.ConversationKey;
 import com.atlassian.plugins.slack.api.notification.NotificationType;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSortedSet;
@@ -81,14 +82,14 @@ public class SpaceToChannelConfiguration {
 
     public static class Builder {
         // Key: channelId
-        private final Map<String, SpaceToChannelSettings.Builder> channelSettingBuilders = new HashMap<>();
+        private final Map<ConversationKey, SpaceToChannelSettings.Builder> channelSettingBuilders = new HashMap<>();
 
         private final Space space;
-        private final Function<String, Optional<SlackChannelDefinition>> channelProvider;
+        private final Function<ConversationKey, Optional<SlackChannelDefinition>> channelProvider;
 
         public Builder(
                 final Space space,
-                final Function<String, Optional<SlackChannelDefinition>> channelProvider) {
+                final Function<ConversationKey, Optional<SlackChannelDefinition>> channelProvider) {
             Preconditions.checkNotNull(space);
             Preconditions.checkNotNull(channelProvider);
             this.space = space;
@@ -103,7 +104,7 @@ public class SpaceToChannelConfiguration {
         public SpaceToChannelConfiguration build() {
             final Map<SlackChannelDefinition, SpaceToChannelSettings> configuration = new HashMap<>();
 
-            channelSettingBuilders.forEach((channelId, value) -> channelProvider.apply(channelId).ifPresent(channel -> {
+            channelSettingBuilders.forEach((conversationKey, value) -> channelProvider.apply(conversationKey).ifPresent(channel -> {
                 SpaceToChannelSettings settings = value.build();
                 configuration.put(channel, settings);
             }));
@@ -117,7 +118,7 @@ public class SpaceToChannelConfiguration {
          * @param channelId the channel id the SpaceToChannelSettings.Builder is for
          * @return a SpaceToChannelSettings.Builder
          */
-        public SpaceToChannelSettings.Builder getSettingsBuilder(String channelId) {
+        public SpaceToChannelSettings.Builder getSettingsBuilder(ConversationKey channelId) {
             SpaceToChannelSettings.Builder builder = channelSettingBuilders.get(channelId);
             if (builder == null) {
                 builder = new SpaceToChannelSettings.Builder();

--- a/confluence-slack-server-integration-plugin/src/main/java/com/atlassian/confluence/plugins/slack/spacetochannel/listener/SlackChannelEventListener.java
+++ b/confluence-slack-server-integration-plugin/src/main/java/com/atlassian/confluence/plugins/slack/spacetochannel/listener/SlackChannelEventListener.java
@@ -16,7 +16,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -73,11 +72,7 @@ public class SlackChannelEventListener extends AutoSubscribingEventListener {
             final List<ConversationKey> mutedChannelIds = settingService.getMutedChannelIds();
             if (!mutedChannelIds.isEmpty()) {
                 Set<ConversationKey> activeConversationIds = event.getConversations().stream()
-                        .flatMap(c -> {
-                            List<ConversationKey> list = new ArrayList<>();
-                            c.getSharedTeamIds().forEach(t -> list.add(new ConversationKey(t, c.getId())));
-                            return list.stream();
-                        })
+                        .map(c -> new ConversationKey(event.getTeamId(), c.getId()))
                         .collect(Collectors.toSet());
                 mutedChannelIds.stream()
                         .filter(activeConversationIds::contains)

--- a/confluence-slack-server-integration-plugin/src/main/java/com/atlassian/confluence/plugins/slack/spacetochannel/service/DefaultSlackSpaceToChannelService.java
+++ b/confluence-slack-server-integration-plugin/src/main/java/com/atlassian/confluence/plugins/slack/spacetochannel/service/DefaultSlackSpaceToChannelService.java
@@ -8,6 +8,7 @@ import com.atlassian.confluence.plugins.slack.spacetochannel.configuration.Space
 import com.atlassian.confluence.spaces.Space;
 import com.atlassian.confluence.spaces.SpaceManager;
 import com.atlassian.plugins.slack.api.ConversationKey;
+import com.atlassian.plugins.slack.api.SlackLink;
 import com.atlassian.plugins.slack.api.client.ConversationLoaderHelper;
 import com.atlassian.plugins.slack.api.client.ConversationsAndLinks;
 import com.atlassian.plugins.slack.api.client.RetryLoaderHelper;
@@ -65,7 +66,7 @@ public class DefaultSlackSpaceToChannelService implements SlackSpaceToChannelSer
         this.transactionTemplate = transactionTemplate;
     }
 
-    private Function<String, Optional<SlackChannelDefinition>> getChannelProvider(
+    private Function<ConversationKey, Optional<SlackChannelDefinition>> getChannelProvider(
             final List<AOEntityToChannelMapping> mappings) {
         // remote user key is stored here because code below is async and can't access request context
         final String userKey = userManager.getRemoteUserKey().getStringValue();
@@ -76,29 +77,32 @@ public class DefaultSlackSpaceToChannelService implements SlackSpaceToChannelSer
                 (slackClient, channel) -> transactionTemplate.execute(() -> slackClient.withUserTokenIfAvailable(userKey)
                         .flatMap(client -> client.getConversationsInfo(channel.getChannelId()).toOptional())));
 
-        return channelId -> conversationsAndLinks.linkByChannelId(channelId)
-                .map(link -> conversationsAndLinks.conversation(new ConversationKey(mappings.iterator().next().getTeamId(), channelId))
-                        .map(conversation -> new SlackChannelDefinition(
-                                link.getTeamName(),
-                                link.getTeamId(),
-                                conversation.getName(),
-                                conversation.getId(),
-                                conversation.isPrivate(),
-                                slackSettingService.isChannelMuted(channelId)))
-                        .orElseGet(() -> new SlackChannelDefinition(
-                                link.getTeamName(),
-                                link.getTeamId(),
-                                "id:" + channelId,
-                                channelId,
-                                true,
-                                slackSettingService.isChannelMuted(channelId))));
+        return conversationKey -> {
+            Optional<SlackLink> slackLink = conversationsAndLinks.linkByConversationKey(conversationKey);
+            return slackLink
+                    .map(link -> conversationsAndLinks.conversation(conversationKey)
+                            .map(conversation -> new SlackChannelDefinition(
+                                    link.getTeamName(),
+                                    link.getTeamId(),
+                                    conversation.getName(),
+                                    conversation.getId(),
+                                    conversation.isPrivate(),
+                                    slackSettingService.isChannelMuted(conversationKey)))
+                            .orElseGet(() -> new SlackChannelDefinition(
+                                    link.getTeamName(),
+                                    link.getTeamId(),
+                                    "id:" + conversationKey.getChannelId(),
+                                    conversationKey.getChannelId(),
+                                    true,
+                                    slackSettingService.isChannelMuted(conversationKey))));
+        };
     }
 
     @Override
     public List<SpaceToChannelConfiguration> getAllSpaceToChannelLinks() {
         if (slackLinkManager.isAnyLinkDefined()) {
             final List<AOEntityToChannelMapping> mappings = entityToChannelMappingManager.getAll();
-            final Function<String, Optional<SlackChannelDefinition>> channelProvider = getChannelProvider(mappings);
+            final Function<ConversationKey, Optional<SlackChannelDefinition>> channelProvider = getChannelProvider(mappings);
             final Map<String, SpaceToChannelConfiguration.Builder> spaceBuildersBySpaceKey = new HashMap<>();
 
             for (AOEntityToChannelMapping mapping : mappings) {
@@ -112,7 +116,7 @@ public class DefaultSlackSpaceToChannelService implements SlackSpaceToChannelSer
                     }
                 }
                 if (builder != null) {
-                    addAOEntityChannelMappingsToBuilder(mapping, builder.getSettingsBuilder(mapping.getChannelId()));
+                    addAOEntityChannelMappingsToBuilder(mapping, builder.getSettingsBuilder(new ConversationKey(mapping.getTeamId(), mapping.getChannelId())));
                 }
             }
 
@@ -134,7 +138,7 @@ public class DefaultSlackSpaceToChannelService implements SlackSpaceToChannelSer
     public SpaceToChannelConfiguration getSpaceToChannelConfiguration(final String spaceKey) {
         Space space = spaceManager.getSpace(spaceKey);
         final List<AOEntityToChannelMapping> mappings = entityToChannelMappingManager.getForEntity(spaceKey);
-        final Function<String, Optional<SlackChannelDefinition>> channelProvider = getChannelProvider(mappings);
+        final Function<ConversationKey, Optional<SlackChannelDefinition>> channelProvider = getChannelProvider(mappings);
 
         SpaceToChannelConfiguration.Builder builder = newConfigBuilder(space, channelProvider);
         addChannelMappingsToBuilder(mappings, builder);
@@ -174,7 +178,7 @@ public class DefaultSlackSpaceToChannelService implements SlackSpaceToChannelSer
     @VisibleForTesting
     SpaceToChannelConfiguration.Builder newConfigBuilder(
             final Space space,
-            final Function<String, Optional<SlackChannelDefinition>> channelProvider) {
+            final Function<ConversationKey, Optional<SlackChannelDefinition>> channelProvider) {
         return new SpaceToChannelConfiguration.Builder(space, channelProvider);
     }
 
@@ -216,7 +220,7 @@ public class DefaultSlackSpaceToChannelService implements SlackSpaceToChannelSer
 
     private void addChannelMappingsToBuilder(List<AOEntityToChannelMapping> mappings, SpaceToChannelConfiguration.Builder builder) {
         for (AOEntityToChannelMapping mapping : mappings) {
-            SpaceToChannelSettings.Builder settingsBuilder = builder.getSettingsBuilder(mapping.getChannelId());
+            SpaceToChannelSettings.Builder settingsBuilder = builder.getSettingsBuilder(new ConversationKey(mapping.getTeamId(), mapping.getChannelId()));
             addAOEntityChannelMappingsToBuilder(mapping, settingsBuilder);
         }
     }

--- a/confluence-slack-server-integration-plugin/src/main/java/com/atlassian/confluence/plugins/slack/spacetochannel/service/DefaultSlackSpaceToChannelService.java
+++ b/confluence-slack-server-integration-plugin/src/main/java/com/atlassian/confluence/plugins/slack/spacetochannel/service/DefaultSlackSpaceToChannelService.java
@@ -77,7 +77,7 @@ public class DefaultSlackSpaceToChannelService implements SlackSpaceToChannelSer
                         .flatMap(client -> client.getConversationsInfo(channel.getChannelId()).toOptional())));
 
         return channelId -> conversationsAndLinks.linkByChannelId(channelId)
-                .map(link -> conversationsAndLinks.conversation(channelId)
+                .map(link -> conversationsAndLinks.conversation(new ConversationKey(mappings.iterator().next().getTeamId(), channelId))
                         .map(conversation -> new SlackChannelDefinition(
                                 link.getTeamName(),
                                 link.getTeamId(),

--- a/confluence-slack-server-integration-plugin/src/test/java/com/atlassian/confluence/plugins/slack/spacetochannel/listener/SlackChannelEventListenerTest.java
+++ b/confluence-slack-server-integration-plugin/src/test/java/com/atlassian/confluence/plugins/slack/spacetochannel/listener/SlackChannelEventListenerTest.java
@@ -1,11 +1,12 @@
 package com.atlassian.confluence.plugins.slack.spacetochannel.listener;
 
 import com.atlassian.confluence.plugins.slack.spacetochannel.service.SlackSpaceToChannelService;
-import com.atlassian.event.api.EventPublisher;
+import com.atlassian.plugins.slack.api.ConversationKey;
 import com.atlassian.plugins.slack.api.events.SlackConversationsLoadedEvent;
 import com.atlassian.plugins.slack.api.webhooks.ChannelArchiveSlackEvent;
 import com.atlassian.plugins.slack.api.webhooks.ChannelDeletedSlackEvent;
 import com.atlassian.plugins.slack.api.webhooks.ChannelUnarchiveSlackEvent;
+import com.atlassian.plugins.slack.api.webhooks.SlackEvent;
 import com.atlassian.plugins.slack.settings.SlackSettingService;
 import com.atlassian.plugins.slack.util.AsyncExecutor;
 import com.github.seratch.jslack.api.model.Conversation;
@@ -26,10 +27,9 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class SlackChannelEventListenerTest {
+    private static final String TEAM_ID = "T";
     private static final String CHANNEL_ID = "C";
 
-    @Mock
-    private EventPublisher eventPublisher;
     @Mock
     private SlackSettingService settingService;
     @Mock
@@ -46,6 +46,8 @@ public class SlackChannelEventListenerTest {
     private Conversation conversation;
     @Mock
     private AsyncExecutor asyncExecutor;
+    @Mock
+    private SlackEvent slackEvent;
 
     @InjectMocks
     private SlackChannelEventListener target;
@@ -53,6 +55,8 @@ public class SlackChannelEventListenerTest {
     @Test
     public void onChannelArchivedEvent_shouldCallExpectedMethods() {
         when(channelArchiveSlackEvent.getChannel()).thenReturn(CHANNEL_ID);
+        when(channelArchiveSlackEvent.getSlackEvent()).thenReturn(slackEvent);
+        when(slackEvent.getTeamId()).thenReturn(TEAM_ID);
         doAnswer(args -> {
             ((Runnable) args.getArgument(0)).run();
             return null;
@@ -60,12 +64,14 @@ public class SlackChannelEventListenerTest {
 
         target.onChannelArchivedEvent(channelArchiveSlackEvent);
 
-        verify(settingService).muteChannel(CHANNEL_ID);
+        verify(settingService).muteChannel(new ConversationKey(TEAM_ID, CHANNEL_ID));
     }
 
     @Test
     public void onChannelUnarchivedEvent_shouldCallExpectedMethods() {
         when(channelUnarchiveSlackEvent.getChannel()).thenReturn(CHANNEL_ID);
+        when(channelUnarchiveSlackEvent.getSlackEvent()).thenReturn(slackEvent);
+        when(slackEvent.getTeamId()).thenReturn(TEAM_ID);
         doAnswer(args -> {
             ((Runnable) args.getArgument(0)).run();
             return null;
@@ -73,12 +79,14 @@ public class SlackChannelEventListenerTest {
 
         target.onChannelUnarchivedEvent(channelUnarchiveSlackEvent);
 
-        verify(settingService).unmuteChannel(CHANNEL_ID);
+        verify(settingService).unmuteChannel(new ConversationKey(TEAM_ID, CHANNEL_ID));
     }
 
     @Test
     public void onChannelDeletedEvent_shouldCallExpectedMethods() {
         when(channelDeletedSlackEvent.getChannel()).thenReturn(CHANNEL_ID);
+        when(channelDeletedSlackEvent.getSlackEvent()).thenReturn(slackEvent);
+        when(slackEvent.getTeamId()).thenReturn(TEAM_ID);
         doAnswer(args -> {
             ((Runnable) args.getArgument(0)).run();
             return null;
@@ -87,15 +95,16 @@ public class SlackChannelEventListenerTest {
         target.onChannelDeletedEvent(channelDeletedSlackEvent);
 
         verify(spaceToChannelService).removeNotificationsForChannel(CHANNEL_ID);
-        verify(settingService).unmuteChannel(CHANNEL_ID);
+        verify(settingService).unmuteChannel(new ConversationKey(TEAM_ID, CHANNEL_ID));
     }
 
     @Test
     public void onConversationsLoadedEvent_shouldCallExpectedMethods() {
         List<Conversation> conversations = Collections.singletonList(conversation);
-        List<String> conversationsStr = Arrays.asList(CHANNEL_ID, "X");
+        List<ConversationKey> mutedConversations = Arrays.asList(new ConversationKey(TEAM_ID, CHANNEL_ID));
         when(conversation.getId()).thenReturn(CHANNEL_ID);
-        when(settingService.getMutedChannelIds()).thenReturn(conversationsStr);
+        when(conversation.getSharedTeamIds()).thenReturn(Arrays.asList(TEAM_ID, "other TEAM_ID"));
+        when(settingService.getMutedChannelIds()).thenReturn(mutedConversations);
         when(slackConversationsLoadedEvent.getConversations()).thenReturn(conversations);
         doAnswer(args -> {
             ((Runnable) args.getArgument(0)).run();
@@ -104,6 +113,6 @@ public class SlackChannelEventListenerTest {
 
         target.onConversationsLoadedEvent(slackConversationsLoadedEvent);
 
-        verify(settingService).unmuteChannel(CHANNEL_ID);
+        verify(settingService).unmuteChannel(new ConversationKey(TEAM_ID, CHANNEL_ID));
     }
 }

--- a/confluence-slack-server-integration-plugin/src/test/java/com/atlassian/confluence/plugins/slack/spacetochannel/listener/SlackChannelEventListenerTest.java
+++ b/confluence-slack-server-integration-plugin/src/test/java/com/atlassian/confluence/plugins/slack/spacetochannel/listener/SlackChannelEventListenerTest.java
@@ -103,8 +103,8 @@ public class SlackChannelEventListenerTest {
         List<Conversation> conversations = Collections.singletonList(conversation);
         List<ConversationKey> mutedConversations = Arrays.asList(new ConversationKey(TEAM_ID, CHANNEL_ID));
         when(conversation.getId()).thenReturn(CHANNEL_ID);
-        when(conversation.getSharedTeamIds()).thenReturn(Arrays.asList(TEAM_ID, "other TEAM_ID"));
         when(settingService.getMutedChannelIds()).thenReturn(mutedConversations);
+        when(slackConversationsLoadedEvent.getTeamId()).thenReturn(TEAM_ID);
         when(slackConversationsLoadedEvent.getConversations()).thenReturn(conversations);
         doAnswer(args -> {
             ((Runnable) args.getArgument(0)).run();

--- a/confluence-slack-server-integration-plugin/src/test/java/com/atlassian/confluence/plugins/slack/spacetochannel/service/DefaultSlackSpaceToChannelServiceTest.java
+++ b/confluence-slack-server-integration-plugin/src/test/java/com/atlassian/confluence/plugins/slack/spacetochannel/service/DefaultSlackSpaceToChannelServiceTest.java
@@ -111,7 +111,7 @@ public class DefaultSlackSpaceToChannelServiceTest {
     public void getAllSpaceToChannelLinks_shouldReturnExpectedValue() {
         List<AOEntityToChannelMapping> mappings = Arrays.asList(entity1, entity2);
         ConversationsAndLinks conversationsAndLinks = new ConversationsAndLinks(
-                ImmutableMap.of(CHANNEL_ID, conversation),
+                ImmutableMap.of(new ConversationKey(TEAM_ID, CHANNEL_ID), conversation),
                 ImmutableMap.of(TEAM_ID, slackLink),
                 ImmutableMap.of(CHANNEL_ID, slackLink, CHANNEL_ID2, slackLink));
 
@@ -150,7 +150,7 @@ public class DefaultSlackSpaceToChannelServiceTest {
     public void getSpaceToChannelConfiguration_shouldReturnExpectedValue() {
         List<AOEntityToChannelMapping> mappings = Arrays.asList(entity1, entity2);
         ConversationsAndLinks conversationsAndLinks = new ConversationsAndLinks(
-                ImmutableMap.of(CHANNEL_ID, conversation),
+                ImmutableMap.of(new ConversationKey(TEAM_ID, CHANNEL_ID), conversation),
                 ImmutableMap.of(TEAM_ID, slackLink),
                 ImmutableMap.of(CHANNEL_ID, slackLink, CHANNEL_ID2, slackLink));
 

--- a/confluence-slack-server-integration-plugin/src/test/java/com/atlassian/confluence/plugins/slack/spacetochannel/service/DefaultSlackSpaceToChannelServiceTest.java
+++ b/confluence-slack-server-integration-plugin/src/test/java/com/atlassian/confluence/plugins/slack/spacetochannel/service/DefaultSlackSpaceToChannelServiceTest.java
@@ -113,14 +113,15 @@ public class DefaultSlackSpaceToChannelServiceTest {
         ConversationsAndLinks conversationsAndLinks = new ConversationsAndLinks(
                 ImmutableMap.of(new ConversationKey(TEAM_ID, CHANNEL_ID), conversation),
                 ImmutableMap.of(TEAM_ID, slackLink),
-                ImmutableMap.of(CHANNEL_ID, slackLink, CHANNEL_ID2, slackLink));
+                ImmutableMap.of(new ConversationKey(TEAM_ID, CHANNEL_ID),
+                        slackLink, new ConversationKey(TEAM_ID, CHANNEL_ID2), slackLink));
 
         when(slackLinkManager.isAnyLinkDefined()).thenReturn(true);
         when(entityToChannelMappingManager.getAll()).thenReturn(mappings);
         when(userManager.getRemoteUserKey()).thenReturn(userKey);
         when(conversationLoaderHelper.conversationsAndLinksById(same(mappings), entityCaptor.capture(), loaderCaptor.capture()))
                 .thenReturn(conversationsAndLinks);
-        when(slackSettingService.isChannelMuted(CHANNEL_ID)).thenReturn(true);
+        when(slackSettingService.isChannelMuted(new ConversationKey(TEAM_ID, CHANNEL_ID))).thenReturn(true);
         when(spaceManager.getSpace(SPACE_KEY)).thenReturn(space);
         when(notificationTypeService.getNotificationTypeForKey(NOTIF_TYPE_KEY)).thenReturn(Optional.of(notificationType));
         when(notificationTypeService.getNotificationTypeForKey(NOTIF_TYPE_KEY2)).thenReturn(Optional.of(notificationType2));
@@ -131,6 +132,7 @@ public class DefaultSlackSpaceToChannelServiceTest {
         when(entity1.getChannelId()).thenReturn(CHANNEL_ID);
         when(entity1.getTeamId()).thenReturn(TEAM_ID);
         when(entity2.getMessageTypeKey()).thenReturn(NOTIF_TYPE_KEY2);
+        when(entity2.getTeamId()).thenReturn(TEAM_ID);
         when(entity2.getEntityKey()).thenReturn(SPACE_KEY);
         when(entity2.getChannelId()).thenReturn(CHANNEL_ID2);
         when(slackLink.getTeamName()).thenReturn(TEAM_NAME);
@@ -152,13 +154,14 @@ public class DefaultSlackSpaceToChannelServiceTest {
         ConversationsAndLinks conversationsAndLinks = new ConversationsAndLinks(
                 ImmutableMap.of(new ConversationKey(TEAM_ID, CHANNEL_ID), conversation),
                 ImmutableMap.of(TEAM_ID, slackLink),
-                ImmutableMap.of(CHANNEL_ID, slackLink, CHANNEL_ID2, slackLink));
+                ImmutableMap.of(new ConversationKey(TEAM_ID, CHANNEL_ID), slackLink,
+                        new ConversationKey(TEAM_ID, CHANNEL_ID2), slackLink));
 
         when(entityToChannelMappingManager.getForEntity(SPACE_KEY)).thenReturn(mappings);
         when(userManager.getRemoteUserKey()).thenReturn(userKey);
         when(conversationLoaderHelper.conversationsAndLinksById(same(mappings), entityCaptor.capture(), loaderCaptor.capture()))
                 .thenReturn(conversationsAndLinks);
-        when(slackSettingService.isChannelMuted(CHANNEL_ID)).thenReturn(true);
+        when(slackSettingService.isChannelMuted(new ConversationKey(TEAM_ID, CHANNEL_ID))).thenReturn(true);
         when(spaceManager.getSpace(SPACE_KEY)).thenReturn(space);
         when(notificationTypeService.getNotificationTypeForKey(NOTIF_TYPE_KEY)).thenReturn(Optional.of(notificationType));
         when(notificationTypeService.getNotificationTypeForKey(NOTIF_TYPE_KEY2)).thenReturn(Optional.of(notificationType2));
@@ -167,6 +170,7 @@ public class DefaultSlackSpaceToChannelServiceTest {
         when(entity1.getMessageTypeKey()).thenReturn(NOTIF_TYPE_KEY);
         when(entity1.getChannelId()).thenReturn(CHANNEL_ID);
         when(entity1.getTeamId()).thenReturn(TEAM_ID);
+        when(entity2.getTeamId()).thenReturn(TEAM_ID);
         when(entity2.getMessageTypeKey()).thenReturn(NOTIF_TYPE_KEY2);
         when(entity2.getChannelId()).thenReturn(CHANNEL_ID2);
         when(slackLink.getTeamName()).thenReturn(TEAM_NAME);

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/manager/impl/DefaultProjectConfigurationManager.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/manager/impl/DefaultProjectConfigurationManager.java
@@ -359,7 +359,8 @@ public class DefaultProjectConfigurationManager implements ProjectConfigurationM
             }
 
             final String channelId = projectConfiguration.getChannelId();
-            final Optional<Conversation> conversation = conversationsAndLinks.conversation(channelId);
+            final ConversationKey conversationKey = new ConversationKey(teamId, channelId);
+            final Optional<Conversation> conversation = conversationsAndLinks.conversation(conversationKey);
             final String channelName = conversation.map(Conversation::getName).orElseGet(() -> "id:" + channelId);
 
             final ProjectConfigurationDTO.Builder configBuilder =

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/model/dto/ProjectToChannelConfigurationDTO.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/model/dto/ProjectToChannelConfigurationDTO.java
@@ -1,5 +1,6 @@
 package com.atlassian.jira.plugins.slack.model.dto;
 
+import com.atlassian.plugins.slack.api.ConversationKey;
 import com.atlassian.plugins.slack.rest.model.SlackChannelDTO;
 import com.google.common.collect.Maps;
 import org.codehaus.jackson.annotate.JsonAutoDetect;
@@ -24,9 +25,9 @@ public class ProjectToChannelConfigurationDTO extends BaseDTO {
     private final long projectId;
     private final String projectName;
     private final String projectKey;
-    private final Map<String, SlackChannelDTO> channels;
-    private final Map<String, List<ConfigurationGroupDTO>> configuration;
-    private final List<String> orderedChannelIds;
+    private final Map<String, SlackChannelDTO> channels; // Map<teamId + : + channelId, ...>
+    private final Map<String, List<ConfigurationGroupDTO>> configuration; // Map<teamId + : + channelId, ...>
+    private final List<ConversationKey> orderedChannelIds;
 
     public ProjectToChannelConfigurationDTO(final long projectId,
                                             final String projectKey,
@@ -36,15 +37,13 @@ public class ProjectToChannelConfigurationDTO extends BaseDTO {
         this.projectName = projectName;
         this.projectKey = projectKey;
 
-        this.configuration = configuration.entrySet().stream().collect(Collectors.toMap(
-                e -> e.getKey().getChannelId(),
-                Map.Entry::getValue
-        ));
+        this.configuration = configuration.entrySet().stream()
+                .collect(Collectors.toMap(e -> e.getKey().getTeamId() + ":" + e.getKey().getChannelId(), Map.Entry::getValue));
 
-        this.channels = Maps.uniqueIndex(configuration.keySet(), SlackChannelDTO::getChannelId);
+        this.channels = Maps.uniqueIndex(configuration.keySet(), channel -> channel.getTeamId() + ":" + channel.getChannelId());
 
         this.orderedChannelIds = configuration.keySet().stream()
-                .map(SlackChannelDTO::getChannelId)
+                .map(conv -> new ConversationKey(conv.getTeamId(), conv.getChannelId()))
                 .collect(Collectors.toList());
     }
 
@@ -69,7 +68,7 @@ public class ProjectToChannelConfigurationDTO extends BaseDTO {
     }
 
     @SuppressWarnings("unused")
-    public List<String> getOrderedChannelIds() {
+    public List<ConversationKey> getOrderedChannelIds() {
         return orderedChannelIds;
     }
 }

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/model/dto/ProjectToChannelConfigurationDTO.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/model/dto/ProjectToChannelConfigurationDTO.java
@@ -27,7 +27,7 @@ public class ProjectToChannelConfigurationDTO extends BaseDTO {
     private final String projectKey;
     private final Map<String, SlackChannelDTO> channels; // Map<teamId + : + channelId, ...>
     private final Map<String, List<ConfigurationGroupDTO>> configuration; // Map<teamId + : + channelId, ...>
-    private final List<ConversationKey> orderedChannelIds;
+    private final List<ConversationKey> orderedConversationKeys;
 
     public ProjectToChannelConfigurationDTO(final long projectId,
                                             final String projectKey,
@@ -42,7 +42,7 @@ public class ProjectToChannelConfigurationDTO extends BaseDTO {
 
         this.channels = Maps.uniqueIndex(configuration.keySet(), channel -> channel.getTeamId() + ":" + channel.getChannelId());
 
-        this.orderedChannelIds = configuration.keySet().stream()
+        this.orderedConversationKeys = configuration.keySet().stream()
                 .map(conv -> new ConversationKey(conv.getTeamId(), conv.getChannelId()))
                 .collect(Collectors.toList());
     }
@@ -68,7 +68,7 @@ public class ProjectToChannelConfigurationDTO extends BaseDTO {
     }
 
     @SuppressWarnings("unused")
-    public List<ConversationKey> getOrderedChannelIds() {
-        return orderedChannelIds;
+    public List<ConversationKey> getOrderedConversationKeys() {
+        return orderedConversationKeys;
     }
 }

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/postfunction/SlackPostFunctionFactory.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/postfunction/SlackPostFunctionFactory.java
@@ -153,8 +153,8 @@ public class SlackPostFunctionFactory extends AbstractWorkflowPluginFactory impl
                         if (!link.isPresent()) {
                             return Stream.empty();
                         }
-
-                        final Optional<Conversation> conversation = conversationsAndLinks.conversation(channelId);
+                        final ConversationKey conversationKey = new ConversationKey(teamId, channelId);
+                        final Optional<Conversation> conversation = conversationsAndLinks.conversation(conversationKey);
                         final String conversationName = conversation.map(Conversation::getName).orElseGet(() -> "id:" + channelId);
                         final boolean isPrivate = conversation.map(Conversation::isPrivate).orElse(false);
                         return Stream.of(new SlackChannelDTO(

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/resources/slack-soy/channelmapping/channelmapping.soy
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/resources/slack-soy/channelmapping/channelmapping.soy
@@ -135,12 +135,12 @@
                     </tr>
                   </thead>
                 {foreach $projectConfiguration in $projectConfigurations}
-                    {foreach $conversationKey in $projectConfiguration.orderedChannelIds} // ConversationKey
+                    {foreach $conversationKey in $projectConfiguration.orderedChannelIds} //ConversationKey
                     {let $convKey: $conversationKey.teamId + ':' + $conversationKey.channelId /}
-                        {foreach $configTeam in $projectConfiguration.configuration[$convKey]} //  List<ConfigurationGroupDTO>
+                        {foreach $configTeam in $projectConfiguration.configuration[$convKey]} //List<ConfigurationGroupDTO>
                         <!-- settings $configTeam.settings  -->
                         <!-- config group id $configTeam.configurationGroupId -->
-                            {call JIRA.Templates.Slack.Project.ChannelMapping.channelMapping} //
+                            {call JIRA.Templates.Slack.Project.ChannelMapping.channelMapping}
                                 {param teamId: $conversationKey.teamId /}
                                 {param teamName: $projectConfiguration.channels[$convKey].teamName /}
                                 {param channelId: $conversationKey.channelId /}
@@ -148,7 +148,7 @@
                                 {param projectName: $projectConfiguration.projectName /}
                                 {param projectKey: $projectConfiguration.projectKey /}
                                 {param projectId: $projectConfiguration.projectId /}
-                                {param config: $configTeam.settings /} //
+                                {param config: $configTeam.settings /}
                                 {param configurationGroupId: $configTeam.configurationGroupId /}
                             {/call}
                         {/foreach}

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/resources/slack-soy/channelmapping/channelmapping.soy
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/resources/slack-soy/channelmapping/channelmapping.soy
@@ -135,9 +135,9 @@
                     </tr>
                   </thead>
                 {foreach $projectConfiguration in $projectConfigurations}
-                    {foreach $conversationKey in $projectConfiguration.orderedChannelIds} //ConversationKey
+                    {foreach $conversationKey in $projectConfiguration.orderedConversationKeys}
                     {let $convKey: $conversationKey.teamId + ':' + $conversationKey.channelId /}
-                        {foreach $configTeam in $projectConfiguration.configuration[$convKey]} //List<ConfigurationGroupDTO>
+                        {foreach $configTeam in $projectConfiguration.configuration[$convKey]}
                         <!-- settings $configTeam.settings  -->
                         <!-- config group id $configTeam.configurationGroupId -->
                             {call JIRA.Templates.Slack.Project.ChannelMapping.channelMapping}

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/resources/slack-soy/channelmapping/channelmapping.soy
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/resources/slack-soy/channelmapping/channelmapping.soy
@@ -135,17 +135,20 @@
                     </tr>
                   </thead>
                 {foreach $projectConfiguration in $projectConfigurations}
-                    {foreach $channelId in $projectConfiguration.orderedChannelIds}
-                        {foreach $configTeam in $projectConfiguration.configuration[$channelId]}
-                            {call JIRA.Templates.Slack.Project.ChannelMapping.channelMapping}
-                                {param teamId: $projectConfiguration.channels[$channelId].teamId /}
-                                {param teamName: $projectConfiguration.channels[$channelId].teamName /}
-                                {param channelId: $channelId /}
-                                {param channelName: $projectConfiguration.channels[$channelId].channelName /}
+                    {foreach $conversationKey in $projectConfiguration.orderedChannelIds} // ConversationKey
+                    {let $convKey: $conversationKey.teamId + ':' + $conversationKey.channelId /}
+                        {foreach $configTeam in $projectConfiguration.configuration[$convKey]} //  List<ConfigurationGroupDTO>
+                        <!-- settings $configTeam.settings  -->
+                        <!-- config group id $configTeam.configurationGroupId -->
+                            {call JIRA.Templates.Slack.Project.ChannelMapping.channelMapping} //
+                                {param teamId: $conversationKey.teamId /}
+                                {param teamName: $projectConfiguration.channels[$convKey].teamName /}
+                                {param channelId: $conversationKey.channelId /}
+                                {param channelName: $projectConfiguration.channels[$convKey].channelName /}
                                 {param projectName: $projectConfiguration.projectName /}
                                 {param projectKey: $projectConfiguration.projectKey /}
                                 {param projectId: $projectConfiguration.projectId /}
-                                {param config: $configTeam.settings /}
+                                {param config: $configTeam.settings /} //
                                 {param configurationGroupId: $configTeam.configurationGroupId /}
                             {/call}
                         {/foreach}

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/test/java/com/atlassian/jira/plugins/slack/manager/impl/DefaultProjectConfigurationManagerTest.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/test/java/com/atlassian/jira/plugins/slack/manager/impl/DefaultProjectConfigurationManagerTest.java
@@ -221,7 +221,7 @@ public class DefaultProjectConfigurationManagerTest {
         assertThat(result.getProjectId(), is(7L));
         assertThat(result.getProjectName(), is("PN"));
         assertThat(result.getProjectKey(), is("PK"));
-        assertThat(result.getOrderedChannelIds(), contains(new ConversationKey("T", "C"), new ConversationKey("T", "NOTC")));
+        assertThat(result.getOrderedConversationKeys(), contains(new ConversationKey("T", "C"), new ConversationKey("T", "NOTC")));
         assertThat(result.getChannels().keySet(), containsInAnyOrder("T:C", "T:NOTC"));
         assertThat(result.getChannels().get("T:C").getChannelId(), is("C"));
         assertThat(result.getChannels().get("T:C").getTeamId(), is("T"));
@@ -325,7 +325,7 @@ public class DefaultProjectConfigurationManagerTest {
         assertThat(projConfigDTO.getProjectId(), is(7L));
         assertThat(projConfigDTO.getProjectName(), is("PN"));
         assertThat(projConfigDTO.getProjectKey(), is("PK"));
-        assertThat(projConfigDTO.getOrderedChannelIds(), contains(new ConversationKey("T", "C"), new ConversationKey("T", "NOTC")));
+        assertThat(projConfigDTO.getOrderedConversationKeys(), contains(new ConversationKey("T", "C"), new ConversationKey("T", "NOTC")));
         assertThat(projConfigDTO.getChannels().keySet(), containsInAnyOrder("T:C", "T:NOTC"));
         assertThat(projConfigDTO.getChannels().get("T:C").getChannelId(), is("C"));
         assertThat(projConfigDTO.getChannels().get("T:C").getTeamId(), is("T"));
@@ -345,7 +345,7 @@ public class DefaultProjectConfigurationManagerTest {
         assertThat(projConfigDTO2.getProjectId(), is(6L));
         assertThat(projConfigDTO2.getProjectName(), is("PN2"));
         assertThat(projConfigDTO2.getProjectKey(), is("PK2"));
-        assertThat(projConfigDTO2.getOrderedChannelIds(), contains(new ConversationKey("T", "C2")));
+        assertThat(projConfigDTO2.getOrderedConversationKeys(), contains(new ConversationKey("T", "C2")));
         assertThat(projConfigDTO2.getChannels().size(), is(1));
         assertThat(projConfigDTO2.getChannels().keySet(), contains("T:C2"));
         assertThat(projConfigDTO2.getChannels().get("T:C2").getChannelId(), is("C2"));

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/test/java/com/atlassian/jira/plugins/slack/manager/impl/DefaultProjectConfigurationManagerTest.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/test/java/com/atlassian/jira/plugins/slack/manager/impl/DefaultProjectConfigurationManagerTest.java
@@ -183,7 +183,8 @@ public class DefaultProjectConfigurationManagerTest {
                 ImmutableMap.of(new ConversationKey("T", "C"), conversation,
                         new ConversationKey("T", "C2"), conversation2),
                 ImmutableMap.of("T", slackLink),
-                ImmutableMap.of("C", slackLink, "C2", slackLink));
+                ImmutableMap.of(new ConversationKey("T", "C"), slackLink,
+                        new ConversationKey("T", "C2"), slackLink));
 
         when(projectConfiguration.getTeamId()).thenReturn("T");
         when(projectConfiguration.getChannelId()).thenReturn("C");
@@ -267,9 +268,11 @@ public class DefaultProjectConfigurationManagerTest {
                 projectConfigurationMissingLink);
 
         ConversationsAndLinks conversationsAndLinks = new ConversationsAndLinks(
-                ImmutableMap.of(new ConversationKey("T", "C"), conversation, new ConversationKey("T", "C2"), conversation2),
+                ImmutableMap.of(new ConversationKey("T", "C"), conversation, new ConversationKey("T",
+                        "C2"), conversation2),
                 ImmutableMap.of("T", slackLink),
-                ImmutableMap.of("C", slackLink, "C2", slackLink));
+                ImmutableMap.of(new ConversationKey("T", "C"), slackLink, new ConversationKey("T",
+                        "C2"), slackLink));
 
         when(projectConfiguration.getTeamId()).thenReturn("T");
         when(projectConfiguration.getChannelId()).thenReturn("C");

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/test/java/com/atlassian/jira/plugins/slack/manager/impl/DefaultProjectConfigurationManagerTest.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/test/java/com/atlassian/jira/plugins/slack/manager/impl/DefaultProjectConfigurationManagerTest.java
@@ -180,7 +180,8 @@ public class DefaultProjectConfigurationManagerTest {
                 projectConfigurationMissingLink);
 
         ConversationsAndLinks conversationsAndLinks = new ConversationsAndLinks(
-                ImmutableMap.of("C", conversation, "C2", conversation2),
+                ImmutableMap.of(new ConversationKey("T", "C"), conversation,
+                        new ConversationKey("T", "C2"), conversation2),
                 ImmutableMap.of("T", slackLink),
                 ImmutableMap.of("C", slackLink, "C2", slackLink));
 
@@ -219,21 +220,21 @@ public class DefaultProjectConfigurationManagerTest {
         assertThat(result.getProjectId(), is(7L));
         assertThat(result.getProjectName(), is("PN"));
         assertThat(result.getProjectKey(), is("PK"));
-        assertThat(result.getOrderedChannelIds(), contains("C", "NOTC"));
-        assertThat(result.getChannels().keySet(), containsInAnyOrder("C", "NOTC"));
-        assertThat(result.getChannels().get("C").getChannelId(), is("C"));
-        assertThat(result.getChannels().get("C").getTeamId(), is("T"));
-        assertThat(result.getChannels().get("C").getChannelName(), is("CNB"));
-        assertThat(result.getChannels().get("C").getTeamName(), is("TN"));
-        assertThat(result.getChannels().get("NOTC").getChannelId(), is("NOTC"));
-        assertThat(result.getChannels().get("NOTC").getTeamId(), is("T"));
-        assertThat(result.getChannels().get("NOTC").getChannelName(), is("id:NOTC"));
-        assertThat(result.getChannels().get("NOTC").getTeamName(), is("TN"));
-        assertThat(result.getConfiguration().keySet(), containsInAnyOrder("C", "NOTC"));
-        assertThat(result.getConfiguration().get("C"), hasSize(1));
-        assertThat(result.getConfiguration().get("C").get(0).getConfigurationGroupId(), is("G"));
-        assertThat(result.getConfiguration().get("C").get(0).getSettings().keySet(), containsInAnyOrder("PCN"));
-        assertThat(result.getConfiguration().get("C").get(0).getSettings().get("PCN").getValue(), is("PCV"));
+        assertThat(result.getOrderedChannelIds(), contains(new ConversationKey("T", "C"), new ConversationKey("T", "NOTC")));
+        assertThat(result.getChannels().keySet(), containsInAnyOrder("T:C", "T:NOTC"));
+        assertThat(result.getChannels().get("T:C").getChannelId(), is("C"));
+        assertThat(result.getChannels().get("T:C").getTeamId(), is("T"));
+        assertThat(result.getChannels().get("T:C").getChannelName(), is("CNB"));
+        assertThat(result.getChannels().get("T:C").getTeamName(), is("TN"));
+        assertThat(result.getChannels().get("T:NOTC").getChannelId(), is("NOTC"));
+        assertThat(result.getChannels().get("T:NOTC").getTeamId(), is("T"));
+        assertThat(result.getChannels().get("T:NOTC").getChannelName(), is("id:NOTC"));
+        assertThat(result.getChannels().get("T:NOTC").getTeamName(), is("TN"));
+        assertThat(result.getConfiguration().keySet(), containsInAnyOrder("T:C", "T:NOTC"));
+        assertThat(result.getConfiguration().get("T:C"), hasSize(1));
+        assertThat(result.getConfiguration().get("T:C").get(0).getConfigurationGroupId(), is("G"));
+        assertThat(result.getConfiguration().get("T:C").get(0).getSettings().keySet(), containsInAnyOrder("PCN"));
+        assertThat(result.getConfiguration().get("T:C").get(0).getSettings().get("PCN").getValue(), is("PCV"));
 
         final ConversationKey convKey = entityCaptor.getValue().apply(projectConfiguration);
         assertThat(convKey.getTeamId(), is("T"));
@@ -266,7 +267,7 @@ public class DefaultProjectConfigurationManagerTest {
                 projectConfigurationMissingLink);
 
         ConversationsAndLinks conversationsAndLinks = new ConversationsAndLinks(
-                ImmutableMap.of("C", conversation, "C2", conversation2),
+                ImmutableMap.of(new ConversationKey("T", "C"), conversation, new ConversationKey("T", "C2"), conversation2),
                 ImmutableMap.of("T", slackLink),
                 ImmutableMap.of("C", slackLink, "C2", slackLink));
 
@@ -321,33 +322,33 @@ public class DefaultProjectConfigurationManagerTest {
         assertThat(projConfigDTO.getProjectId(), is(7L));
         assertThat(projConfigDTO.getProjectName(), is("PN"));
         assertThat(projConfigDTO.getProjectKey(), is("PK"));
-        assertThat(projConfigDTO.getOrderedChannelIds(), contains("C", "NOTC"));
-        assertThat(projConfigDTO.getChannels().keySet(), containsInAnyOrder("C", "NOTC"));
-        assertThat(projConfigDTO.getChannels().get("C").getChannelId(), is("C"));
-        assertThat(projConfigDTO.getChannels().get("C").getTeamId(), is("T"));
-        assertThat(projConfigDTO.getChannels().get("C").getChannelName(), is("CNB"));
-        assertThat(projConfigDTO.getChannels().get("C").getTeamName(), is("TN"));
-        assertThat(projConfigDTO.getChannels().get("NOTC").getChannelId(), is("NOTC"));
-        assertThat(projConfigDTO.getChannels().get("NOTC").getTeamId(), is("T"));
-        assertThat(projConfigDTO.getChannels().get("NOTC").getChannelName(), is("id:NOTC"));
-        assertThat(projConfigDTO.getChannels().get("NOTC").getTeamName(), is("TN"));
-        assertThat(projConfigDTO.getConfiguration().keySet(), containsInAnyOrder("C", "NOTC"));
-        assertThat(projConfigDTO.getConfiguration().get("C"), hasSize(1));
-        assertThat(projConfigDTO.getConfiguration().get("C").get(0).getConfigurationGroupId(), is("G"));
-        assertThat(projConfigDTO.getConfiguration().get("C").get(0).getSettings().keySet(), containsInAnyOrder("PCN"));
-        assertThat(projConfigDTO.getConfiguration().get("C").get(0).getSettings().get("PCN").getValue(), is("PCV"));
+        assertThat(projConfigDTO.getOrderedChannelIds(), contains(new ConversationKey("T", "C"), new ConversationKey("T", "NOTC")));
+        assertThat(projConfigDTO.getChannels().keySet(), containsInAnyOrder("T:C", "T:NOTC"));
+        assertThat(projConfigDTO.getChannels().get("T:C").getChannelId(), is("C"));
+        assertThat(projConfigDTO.getChannels().get("T:C").getTeamId(), is("T"));
+        assertThat(projConfigDTO.getChannels().get("T:C").getChannelName(), is("CNB"));
+        assertThat(projConfigDTO.getChannels().get("T:C").getTeamName(), is("TN"));
+        assertThat(projConfigDTO.getChannels().get("T:NOTC").getChannelId(), is("NOTC"));
+        assertThat(projConfigDTO.getChannels().get("T:NOTC").getTeamId(), is("T"));
+        assertThat(projConfigDTO.getChannels().get("T:NOTC").getChannelName(), is("id:NOTC"));
+        assertThat(projConfigDTO.getChannels().get("T:NOTC").getTeamName(), is("TN"));
+        assertThat(projConfigDTO.getConfiguration().keySet(), containsInAnyOrder("T:C", "T:NOTC"));
+        assertThat(projConfigDTO.getConfiguration().get("T:C"), hasSize(1));
+        assertThat(projConfigDTO.getConfiguration().get("T:C").get(0).getConfigurationGroupId(), is("G"));
+        assertThat(projConfigDTO.getConfiguration().get("T:C").get(0).getSettings().keySet(), containsInAnyOrder("PCN"));
+        assertThat(projConfigDTO.getConfiguration().get("T:C").get(0).getSettings().get("PCN").getValue(), is("PCV"));
 
         final ProjectToChannelConfigurationDTO projConfigDTO2 = result.get(1);
         assertThat(projConfigDTO2.getProjectId(), is(6L));
         assertThat(projConfigDTO2.getProjectName(), is("PN2"));
         assertThat(projConfigDTO2.getProjectKey(), is("PK2"));
-        assertThat(projConfigDTO2.getOrderedChannelIds(), contains("C2"));
+        assertThat(projConfigDTO2.getOrderedChannelIds(), contains(new ConversationKey("T", "C2")));
         assertThat(projConfigDTO2.getChannels().size(), is(1));
-        assertThat(projConfigDTO2.getChannels().keySet(), contains("C2"));
-        assertThat(projConfigDTO2.getChannels().get("C2").getChannelId(), is("C2"));
-        assertThat(projConfigDTO2.getChannels().get("C2").getTeamId(), is("T"));
-        assertThat(projConfigDTO2.getChannels().get("C2").getChannelName(), is("CNA"));
-        assertThat(projConfigDTO2.getChannels().get("C2").getTeamName(), is("TN"));
+        assertThat(projConfigDTO2.getChannels().keySet(), contains("T:C2"));
+        assertThat(projConfigDTO2.getChannels().get("T:C2").getChannelId(), is("C2"));
+        assertThat(projConfigDTO2.getChannels().get("T:C2").getTeamId(), is("T"));
+        assertThat(projConfigDTO2.getChannels().get("T:C2").getChannelName(), is("CNA"));
+        assertThat(projConfigDTO2.getChannels().get("T:C2").getTeamName(), is("TN"));
 
         final ConversationKey convKey = entityCaptor.getValue().apply(projectConfiguration);
         assertThat(convKey.getTeamId(), is("T"));

--- a/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/api/ConversationKey.java
+++ b/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/api/ConversationKey.java
@@ -4,6 +4,15 @@ import lombok.Value;
 
 @Value
 public class ConversationKey {
-    private final String teamId;
-    private final String channelId;
+    String teamId;
+    String channelId;
+
+    public String toStringKey() {
+        return teamId + ":" + channelId;
+    }
+
+    public static ConversationKey fromStringKey(String conversationKey) {
+        String[] arr = conversationKey.split(":");
+        return new ConversationKey(arr[0], arr[1]);
+    }
 }

--- a/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/api/client/ConversationLoaderHelper.java
+++ b/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/api/client/ConversationLoaderHelper.java
@@ -81,10 +81,10 @@ public class ConversationLoaderHelper implements InitializingBean, DisposableBea
                 .collect(Collectors.toMap(SlackLink::getTeamId, Function.identity()));
 
         // index links by channel
-        final Map<String, SlackLink> linksByChannelId = channels.stream()
+        final Map<ConversationKey, SlackLink> linksByChannelId = channels.stream()
                 .filter(key -> linksByTeamId.containsKey(key.getTeamId()))
                 .collect(toMap(
-                        ConversationKey::getChannelId,
+                        Function.identity(),
                         key -> linksByTeamId.get(key.getTeamId()),
                         (k1, k2) -> k1));
 
@@ -122,7 +122,7 @@ public class ConversationLoaderHelper implements InitializingBean, DisposableBea
      */
     private Future<Optional<Pair<ConversationKey, Conversation>>> loadConversationFromList(
             final ConversationKey conversationKey,
-            final Map<String, SlackLink> linksByChannelId,
+            final Map<ConversationKey, SlackLink> linksByChannelId,
             final BiFunction<SlackClient, ConversationKey, Optional<Conversation>> loader) {
         return executorService.submit(() -> Optional
                 .ofNullable(linksByChannelId.get(conversationKey.getChannelId()))

--- a/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/api/client/ConversationsAndLinks.java
+++ b/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/api/client/ConversationsAndLinks.java
@@ -10,14 +10,14 @@ import java.util.Optional;
 public class ConversationsAndLinks {
     private final Map<ConversationKey, Conversation> conversations;
     private final Map<String, SlackLink> links;
-    private final Map<String, SlackLink> linksByChannelId;
+    private final Map<ConversationKey, SlackLink> linksByConversationKey;
 
     public ConversationsAndLinks(final Map<ConversationKey, Conversation> conversations,
                                  final Map<String, SlackLink> links,
-                                 final Map<String, SlackLink> linksByChannelId) {
+                                 final Map<ConversationKey, SlackLink> linksByConversationKey) {
         this.conversations = conversations;
         this.links = links;
-        this.linksByChannelId = linksByChannelId;
+        this.linksByConversationKey = linksByConversationKey;
     }
 
     public Optional<Conversation> conversation(final ConversationKey conversationKey) {
@@ -28,7 +28,7 @@ public class ConversationsAndLinks {
         return Optional.ofNullable(links.get(teamId));
     }
 
-    public Optional<SlackLink> linkByChannelId(final String channelId) {
-        return Optional.ofNullable(linksByChannelId.get(channelId));
+    public Optional<SlackLink> linkByConversationKey(final ConversationKey conversationKey) {
+        return Optional.ofNullable(linksByConversationKey.get(conversationKey));
     }
 }

--- a/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/api/client/ConversationsAndLinks.java
+++ b/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/api/client/ConversationsAndLinks.java
@@ -1,5 +1,6 @@
 package com.atlassian.plugins.slack.api.client;
 
+import com.atlassian.plugins.slack.api.ConversationKey;
 import com.atlassian.plugins.slack.api.SlackLink;
 import com.github.seratch.jslack.api.model.Conversation;
 
@@ -7,11 +8,11 @@ import java.util.Map;
 import java.util.Optional;
 
 public class ConversationsAndLinks {
-    private final Map<String, Conversation> conversations;
+    private final Map<ConversationKey, Conversation> conversations;
     private final Map<String, SlackLink> links;
     private final Map<String, SlackLink> linksByChannelId;
 
-    public ConversationsAndLinks(final Map<String, Conversation> conversations,
+    public ConversationsAndLinks(final Map<ConversationKey, Conversation> conversations,
                                  final Map<String, SlackLink> links,
                                  final Map<String, SlackLink> linksByChannelId) {
         this.conversations = conversations;
@@ -19,8 +20,8 @@ public class ConversationsAndLinks {
         this.linksByChannelId = linksByChannelId;
     }
 
-    public Optional<Conversation> conversation(final String channelId) {
-        return Optional.ofNullable(conversations.get(channelId));
+    public Optional<Conversation> conversation(final ConversationKey conversationKey) {
+        return Optional.ofNullable(conversations.get(conversationKey));
     }
 
     public Optional<SlackLink> link(final String teamId) {

--- a/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/api/client/DefaultSlackClient.java
+++ b/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/api/client/DefaultSlackClient.java
@@ -343,7 +343,7 @@ public class DefaultSlackClient implements SlackClient {
 
         return result.map(conversations -> {
             // check 'is_archived' flag and unmute mappings
-            eventPublisher.publish(new SlackConversationsLoadedEvent(conversations));
+            eventPublisher.publish(new SlackConversationsLoadedEvent(conversations, slackLink.getTeamId()));
             return conversations;
         });
     }

--- a/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/api/descriptor/DefaultNotificationTypeService.java
+++ b/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/api/descriptor/DefaultNotificationTypeService.java
@@ -4,6 +4,7 @@ import com.atlassian.event.api.EventPublisher;
 import com.atlassian.ozymandias.SafeAccessViaPluginAccessor;
 import com.atlassian.ozymandias.SafePluginPointAccess;
 import com.atlassian.plugin.PluginAccessor;
+import com.atlassian.plugins.slack.api.ConversationKey;
 import com.atlassian.plugins.slack.api.notification.BaseSlackEvent;
 import com.atlassian.plugins.slack.api.notification.NotificationType;
 import com.atlassian.plugins.slack.api.notification.SlackNotification;
@@ -110,7 +111,7 @@ public class DefaultNotificationTypeService implements NotificationTypeService {
                     module.getSlackMessage(event).ifPresent(message ->
                             context.get().getChannels(event, notificationType).stream()
                                     // if the channel was archived, skip sending notifications to it
-                                    .filter(channel -> !slackSettingService.isChannelMuted(channel.getChannelId()))
+                                    .filter(channel -> !slackSettingService.isChannelMuted(new ConversationKey(channel.getTeamId(), channel.getChannelId())))
                                     .forEach(channel ->
                                             messages.add(new ChannelNotification(
                                                     channel.getTeamId(),

--- a/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/api/events/SlackConversationsLoadedEvent.java
+++ b/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/api/events/SlackConversationsLoadedEvent.java
@@ -6,12 +6,18 @@ import java.util.List;
 
 public class SlackConversationsLoadedEvent {
     private final List<Conversation> conversations;
+    private final String teamId;
 
-    public SlackConversationsLoadedEvent(List<Conversation> conversations) {
+    public SlackConversationsLoadedEvent(List<Conversation> conversations, String teamId) {
         this.conversations = conversations;
+        this.teamId = teamId;
     }
 
     public List<Conversation> getConversations() {
         return conversations;
+    }
+
+    public String getTeamId() {
+        return teamId;
     }
 }

--- a/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/settings/DefaultSlackSettingsService.java
+++ b/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/settings/DefaultSlackSettingsService.java
@@ -1,5 +1,6 @@
 package com.atlassian.plugins.slack.settings;
 
+import com.atlassian.plugins.slack.api.ConversationKey;
 import com.atlassian.sal.api.pluginsettings.PluginSettings;
 import com.atlassian.sal.api.pluginsettings.PluginSettingsFactory;
 import com.atlassian.sal.api.transaction.TransactionTemplate;
@@ -29,11 +30,11 @@ public class DefaultSlackSettingsService implements SlackSettingService {
     private final TransactionTemplate transactionTemplate;
 
     @Override
-    public boolean isChannelMuted(final String channelId) {
+    public boolean isChannelMuted(final ConversationKey conversationKey) {
         boolean isMuted = false;
-        if (StringUtils.isNotBlank(channelId)) {
+        if (StringUtils.isNotBlank(conversationKey.toString())) {
             List<String> mutedChannelIds = getMutedChannelIds();
-            isMuted = mutedChannelIds.contains(channelId);
+            isMuted = mutedChannelIds.contains(conversationKey);
         }
         return isMuted;
     }

--- a/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/settings/SlackSettingService.java
+++ b/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/settings/SlackSettingService.java
@@ -1,9 +1,11 @@
 package com.atlassian.plugins.slack.settings;
 
+import com.atlassian.plugins.slack.api.ConversationKey;
+
 import java.util.List;
 
 public interface SlackSettingService {
-    boolean isChannelMuted(String channelId);
+    boolean isChannelMuted(ConversationKey conversationKey);
 
     void muteChannel(String channelId);
 

--- a/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/settings/SlackSettingService.java
+++ b/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/settings/SlackSettingService.java
@@ -7,11 +7,11 @@ import java.util.List;
 public interface SlackSettingService {
     boolean isChannelMuted(ConversationKey conversationKey);
 
-    void muteChannel(String channelId);
+    void muteChannel(ConversationKey conversationKey);
 
-    void unmuteChannel(String channelId);
+    void unmuteChannel(ConversationKey conversationKey);
 
-    List<String> getMutedChannelIds();
+    List<ConversationKey> getMutedChannelIds();
 
     boolean isInstancePublic();
 

--- a/slack-server-integration-common/src/test/java/com/atlassian/plugins/slack/api/descriptor/DefaultNotificationTypeServiceTest.java
+++ b/slack-server-integration-common/src/test/java/com/atlassian/plugins/slack/api/descriptor/DefaultNotificationTypeServiceTest.java
@@ -2,6 +2,7 @@ package com.atlassian.plugins.slack.api.descriptor;
 
 import com.atlassian.event.api.EventPublisher;
 import com.atlassian.plugin.PluginAccessor;
+import com.atlassian.plugins.slack.api.ConversationKey;
 import com.atlassian.plugins.slack.api.events.NotificationBlockedEvent;
 import com.atlassian.plugins.slack.api.notification.BaseSlackEvent;
 import com.atlassian.plugins.slack.api.notification.ChannelToNotify;
@@ -187,8 +188,8 @@ public class DefaultNotificationTypeServiceTest {
         when(slackNotification.getSlackMessage(event)).thenReturn(java.util.Optional.of(messageRequestBuilder));
         when(slackNotificationContext.getChannels(same(event), argThat(n -> Matchers.is("d1").matches(n.getKey()))))
                 .thenReturn(Arrays.asList(channelToNotify1, channelToNotify2));
-        when(slackSettingService.isChannelMuted("C1")).thenReturn(true);
-        when(slackSettingService.isChannelMuted("C2")).thenReturn(false);
+        when(slackSettingService.isChannelMuted(new ConversationKey("", "C1"))).thenReturn(true);
+        when(slackSettingService.isChannelMuted(new ConversationKey("T", "C2"))).thenReturn(false);
         when(messageRequestBuilder.threadTs("T2")).thenReturn(messageRequestBuilder);
 
         List<NotificationTypeService.ChannelNotification> result = target.getNotificationsForEvent(event);

--- a/slack-server-integration-common/src/test/java/com/atlassian/plugins/slack/settings/DefaultSlackSettingsServiceTest.java
+++ b/slack-server-integration-common/src/test/java/com/atlassian/plugins/slack/settings/DefaultSlackSettingsServiceTest.java
@@ -1,5 +1,6 @@
 package com.atlassian.plugins.slack.settings;
 
+import com.atlassian.plugins.slack.api.ConversationKey;
 import com.atlassian.sal.api.pluginsettings.PluginSettings;
 import com.atlassian.sal.api.pluginsettings.PluginSettingsFactory;
 import com.atlassian.sal.api.transaction.TransactionCallback;
@@ -75,10 +76,10 @@ public class DefaultSlackSettingsServiceTest {
 
     @Test
     public void isChannelMuted_shouldReturnExpectedValue() {
-        List<String> list = Collections.singletonList("C");
+        List<ConversationKey> list = Collections.singletonList(new ConversationKey("T", "C"));
         when(pluginSettings.get(MUTED_CHANNEL_IDS_OPTION_NAME)).thenReturn(list);
 
-        boolean result = target.isChannelMuted("C");
+        boolean result = target.isChannelMuted(new ConversationKey("T", "C"));
 
         assertThat(result, is(true));
     }
@@ -86,17 +87,17 @@ public class DefaultSlackSettingsServiceTest {
 
     @Test
     public void isChannelMuted_shouldReturnFalseWhenChannelIsNotMted() {
-        List<String> list = Collections.singletonList("C");
+        List<ConversationKey> list = Collections.singletonList(new ConversationKey("T", "C"));
         when(pluginSettings.get(MUTED_CHANNEL_IDS_OPTION_NAME)).thenReturn(list);
 
-        boolean result = target.isChannelMuted("C2");
+        boolean result = target.isChannelMuted(new ConversationKey("T", "C2"));
 
         assertThat(result, is(false));
     }
 
     @Test
     public void isChannelMuted_shouldReturnFalseWhenChannelIdIsEmpty() {
-        boolean result = target.isChannelMuted("");
+        boolean result = target.isChannelMuted(new ConversationKey("T", ""));
 
         assertThat(result, is(false));
     }


### PR DESCRIPTION
I replaced channelId to composite Key - class ConversationKey that contains teamId and channelId