### PR TITLE
#103: Fixed sending personal notification about adding user as a reviewer on PR creation

### DIFF
--- a/bitbucket-slack-server-integration-plugin/src/main/java/com/atlassian/bitbucket/plugins/slack/model/ExtendedChannelToNotify.java
+++ b/bitbucket-slack-server-integration-plugin/src/main/java/com/atlassian/bitbucket/plugins/slack/model/ExtendedChannelToNotify.java
@@ -1,10 +1,15 @@
 package com.atlassian.bitbucket.plugins.slack.model;
 
+import com.atlassian.bitbucket.user.ApplicationUser;
 import com.atlassian.plugins.slack.api.notification.ChannelToNotify;
 import lombok.Value;
+
+import javax.annotation.Nullable;
 
 @Value
 public class ExtendedChannelToNotify {
     ChannelToNotify channel;
     String notificationKey;
+    @Nullable
+    ApplicationUser applicationUser;
 }

--- a/bitbucket-slack-server-integration-plugin/src/main/java/com/atlassian/bitbucket/plugins/slack/model/NotificationRenderingOptions.java
+++ b/bitbucket-slack-server-integration-plugin/src/main/java/com/atlassian/bitbucket/plugins/slack/model/NotificationRenderingOptions.java
@@ -1,10 +1,15 @@
 package com.atlassian.bitbucket.plugins.slack.model;
 
+import com.atlassian.bitbucket.user.ApplicationUser;
 import com.atlassian.plugins.slack.api.notification.Verbosity;
 import lombok.Value;
+
+import javax.annotation.Nullable;
 
 @Value
 public class NotificationRenderingOptions {
     Verbosity verbosity;
     boolean isPersonal;
+    @Nullable
+    ApplicationUser applicationUser;
 }

--- a/bitbucket-slack-server-integration-plugin/src/main/java/com/atlassian/bitbucket/plugins/slack/notification/BitbucketPersonalNotificationTypes.java
+++ b/bitbucket-slack-server-integration-plugin/src/main/java/com/atlassian/bitbucket/plugins/slack/notification/BitbucketPersonalNotificationTypes.java
@@ -18,7 +18,7 @@ public enum BitbucketPersonalNotificationTypes {
      */
     PR_REVIEWER_CREATED,
     /**
-     * Tell me about all updates in a PR I’m a reviewer
+     * Tell me about all updates in a PR I’m a reviewer of
      */
     PR_REVIEWER_UPDATED
 }

--- a/bitbucket-slack-server-integration-plugin/src/main/java/com/atlassian/bitbucket/plugins/slack/notification/NotificationPublisher.java
+++ b/bitbucket-slack-server-integration-plugin/src/main/java/com/atlassian/bitbucket/plugins/slack/notification/NotificationPublisher.java
@@ -68,7 +68,7 @@ public class NotificationPublisher {
             final Verbosity verbosity = bitbucketSlackSettingsService.getVerbosity(
                     repository.getId(), channelToNotify.getTeamId(), channelToNotify.getChannelId());
             messageProvider
-                    .apply(new NotificationRenderingOptions(verbosity, channelToNotify.isPersonal()))
+                    .apply(new NotificationRenderingOptions(verbosity, channelToNotify.isPersonal(), channel.getApplicationUser()))
                     .ifPresent(message -> {
                         AnalyticsContext context = analyticsContextProvider.byTeamId(channelToNotify.getTeamId());
                         eventPublisher.publish(new BitbucketNotificationSentEvent(context, channel.getNotificationKey(),
@@ -86,7 +86,7 @@ public class NotificationPublisher {
                 .build();
         Set<ChannelToNotify> channels = notificationConfigurationService.getChannelsToNotify(request);
         return channels.stream()
-                .map(channel -> new ExtendedChannelToNotify(channel, notificationTypeKey))
+                .map(channel -> new ExtendedChannelToNotify(channel, notificationTypeKey, null))
                 .collect(Collectors.toSet());
     }
 

--- a/bitbucket-slack-server-integration-plugin/src/main/java/com/atlassian/bitbucket/plugins/slack/notification/renderer/SlackNotificationRenderer.java
+++ b/bitbucket-slack-server-integration-plugin/src/main/java/com/atlassian/bitbucket/plugins/slack/notification/renderer/SlackNotificationRenderer.java
@@ -317,17 +317,14 @@ public class SlackNotificationRenderer {
         return standardBlockMessage(text);
     }
 
-    public ChatPostMessageRequestBuilder getReviewersPullRequestMessage(
-            final PullRequestReviewersUpdatedEvent event,
-            final boolean isVerbose) {
-        final PullRequest pullRequest = event.getPullRequest();
+    public ChatPostMessageRequestBuilder getReviewersPullRequestMessage(final PullRequest pullRequest,
+                                                                        final ApplicationUser actor,
+                                                                        final boolean hasUserJoinedPr,
+                                                                        final boolean isVerbose) {
         final PullRequestRef toRef = pullRequest.getToRef();
         final Repository repository = toRef.getRepository();
-        final ApplicationUser actor = event.getUser();
-        final Collection<ApplicationUser> addedReviewers = ObjectUtils.firstNonNull(event.getAddedReviewers(), emptyList());
-        final boolean isOneUserAdded = addedReviewers.size() == 1;
 
-        final String suffix = isOneUserAdded ? "joined" : "removed";
+        final String suffix = hasUserJoinedPr ? "joined" : "removed";
         final String verboseSuffix = isVerbose ? ".long" : ".short";
         final String text = i18nResolver.getText(
                 "slack.activity.pr.reviewers." + suffix + verboseSuffix,

--- a/bitbucket-slack-server-integration-plugin/src/test/java/com/atlassian/bitbucket/plugins/slack/listener/BitbucketNotificationEventListenerTest.java
+++ b/bitbucket-slack-server-integration-plugin/src/test/java/com/atlassian/bitbucket/plugins/slack/listener/BitbucketNotificationEventListenerTest.java
@@ -162,7 +162,7 @@ class BitbucketNotificationEventListenerTest {
     @InjectMocks
     private BitbucketNotificationEventListener target;
 
-    private NotificationRenderingOptions extendedOptions = new NotificationRenderingOptions(Verbosity.EXTENDED, false);
+    private NotificationRenderingOptions extendedOptions = new NotificationRenderingOptions(Verbosity.EXTENDED, false, null);
 
     private void testPullRequestBlockerCommentEvent(PullRequestCommentEvent event, TaskNotificationTypes type) {
         when(event.getComment()).thenReturn(comment);
@@ -234,7 +234,7 @@ class BitbucketNotificationEventListenerTest {
         testPullRequestEvent(event, type, "PR title", reviewers);
     }
 
-    void testPullRequestEvent(PullRequestEvent event, PullRequestNotificationTypes type, String prTitle, boolean reviewers) {
+    void testPullRequestEvent(PullRequestEvent event, PullRequestNotificationTypes type, String prTitle, boolean isReviewersUpdate) {
         when(event.getPullRequest()).thenReturn(pullRequest);
         when(pullRequest.getTitle()).thenReturn(prTitle);
         when(pullRequest.getToRef()).thenReturn(pullRequestRef);
@@ -250,8 +250,8 @@ class BitbucketNotificationEventListenerTest {
                 captor.capture());
 
         captor.getValue().apply(extendedOptions);
-        if (reviewers) {
-            verify(slackNotificationRenderer).getReviewersPullRequestMessage((PullRequestReviewersUpdatedEvent) event, true);
+        if (isReviewersUpdate) {
+            verify(slackNotificationRenderer).getReviewersPullRequestMessage(pullRequest, user, true, true);
         } else {
             verify(slackNotificationRenderer).getPullRequestMessage(event);
         }

--- a/bitbucket-slack-server-integration-plugin/src/test/java/com/atlassian/bitbucket/plugins/slack/notification/configuration/PersonalNotificationServiceTest.java
+++ b/bitbucket-slack-server-integration-plugin/src/test/java/com/atlassian/bitbucket/plugins/slack/notification/configuration/PersonalNotificationServiceTest.java
@@ -123,7 +123,7 @@ public class PersonalNotificationServiceTest {
         Set<ExtendedChannelToNotify> channels = target.findNotificationsFor(currentUser, commitDiscussion);
 
         assertThat(channels, contains(new ExtendedChannelToNotify(new ChannelToNotify(TEAM_ID, SLACK_USER_ID, null, true),
-                "commit_author_comment")));
+                "commit_author_comment", commitAuthor)));
     }
 
     @Test
@@ -143,10 +143,10 @@ public class PersonalNotificationServiceTest {
         when(slackUser.getSlackUserId()).thenReturn(SLACK_USER_ID);
         when(watcherService.search(any(), any())).thenReturn(new PageImpl<>(new PageRequestImpl(0, 10), Collections.emptySet(), true));
 
-        Set<ExtendedChannelToNotify> channels = target.findNotificationsFor(currentUser, pullRequest, Collections.emptySet(), false);
+        Set<ExtendedChannelToNotify> channels = target.findNotificationsFor(currentUser, pullRequest, Collections.emptySet());
 
         assertThat(channels, contains(new ExtendedChannelToNotify(new ChannelToNotify(TEAM_ID, SLACK_USER_ID, null, true),
-                "pr_author")));
+                "pr_author", authorUser)));
     }
 
     @Test
@@ -168,10 +168,10 @@ public class PersonalNotificationServiceTest {
         when(slackUser.getUserToken()).thenReturn("someUserToken");
         when(slackUser.getSlackUserId()).thenReturn(SLACK_USER_ID);
 
-        Set<ExtendedChannelToNotify> channels = target.findNotificationsFor(currentUser, pullRequest, Collections.emptySet(), false);
+        Set<ExtendedChannelToNotify> channels = target.findNotificationsFor(currentUser, pullRequest, Collections.emptySet());
 
         assertThat(channels, contains(new ExtendedChannelToNotify(new ChannelToNotify(TEAM_ID, SLACK_USER_ID, null, true),
-                "pr_watcher")));
+                "pr_watcher", watcherUser)));
     }
 
     @Test
@@ -193,10 +193,10 @@ public class PersonalNotificationServiceTest {
         when(slackUser.getUserToken()).thenReturn("someUserToken");
         when(slackUser.getSlackUserId()).thenReturn(SLACK_USER_ID);
 
-        Set<ExtendedChannelToNotify> channels = target.findNotificationsFor(currentUser, pullRequest, Collections.emptySet(), true);
+        Set<ExtendedChannelToNotify> channels = target.findNotificationsFor(currentUser, pullRequest, Collections.singleton(reviewerUser));
 
         assertThat(channels, contains(new ExtendedChannelToNotify(new ChannelToNotify(TEAM_ID, SLACK_USER_ID, null, true),
-                "pr_reviewer_created")));
+                "pr_reviewer_created", reviewerUser)));
     }
 
     @Test
@@ -218,9 +218,9 @@ public class PersonalNotificationServiceTest {
         when(slackUser.getUserToken()).thenReturn("someUserToken");
         when(slackUser.getSlackUserId()).thenReturn(SLACK_USER_ID);
 
-        Set<ExtendedChannelToNotify> channels = target.findNotificationsFor(currentUser, pullRequest, Collections.emptySet(), false);
+        Set<ExtendedChannelToNotify> channels = target.findNotificationsFor(currentUser, pullRequest, Collections.emptySet());
 
         assertThat(channels, contains(new ExtendedChannelToNotify(new ChannelToNotify(TEAM_ID, SLACK_USER_ID, null, true),
-                "pr_reviewer_updated")));
+                "pr_reviewer_updated", reviewerUser)));
     }
 }

--- a/bitbucket-slack-server-integration-plugin/src/test/java/com/atlassian/bitbucket/plugins/slack/notification/renderer/SlackNotificationRendererTest.java
+++ b/bitbucket-slack-server-integration-plugin/src/test/java/com/atlassian/bitbucket/plugins/slack/notification/renderer/SlackNotificationRendererTest.java
@@ -516,7 +516,7 @@ public class SlackNotificationRendererTest {
         when(pullRequestReviewersUpdatedEvent.getUser()).thenReturn(user);
         when(pullRequestReviewersUpdatedEvent.getAddedReviewers()).thenReturn(Collections.singleton(user));
 
-        ChatPostMessageRequest result = renderer.getReviewersPullRequestMessage(pullRequestReviewersUpdatedEvent, true).build();
+        ChatPostMessageRequest result = renderer.getReviewersPullRequestMessage(pullRequest, user, true, true).build();
 
         assertMessage(result, join("slack.activity.pr.reviewers.joined.long", USER_SLACK_LINK, PR_SLACK_LINK, REPO_SLACK_LINK,
                 PR_FROM_BRANCH_LINK, PR_TO_BRANCH_LINK));
@@ -528,7 +528,7 @@ public class SlackNotificationRendererTest {
         when(pullRequestReviewersUpdatedEvent.getUser()).thenReturn(user);
         when(pullRequestReviewersUpdatedEvent.getRemovedReviewers()).thenReturn(Collections.singleton(user));
 
-        ChatPostMessageRequest result = renderer.getReviewersPullRequestMessage(pullRequestReviewersUpdatedEvent, false).build();
+        ChatPostMessageRequest result = renderer.getReviewersPullRequestMessage(pullRequest, user, false, false).build();
 
         assertMessage(result, join("slack.activity.pr.reviewers.removed.short", USER_SLACK_LINK, PR_SLACK_LINK, REPO_SLACK_LINK,
                 PR_FROM_BRANCH_LINK, PR_TO_BRANCH_LINK));


### PR DESCRIPTION
There was handling one of a few event listeners. I added handling event when user add reviewer on PR creation