### PR TITLE
#122: Slack notification correctly refers to the comment creator when a user adds a comment in a page

### DIFF
--- a/confluence-slack-server-integration-plugin/src/main/java/com/atlassian/confluence/plugins/slack/spacetochannel/listener/ConfluenceEventListener.java
+++ b/confluence-slack-server-integration-plugin/src/main/java/com/atlassian/confluence/plugins/slack/spacetochannel/listener/ConfluenceEventListener.java
@@ -102,7 +102,7 @@ public class ConfluenceEventListener extends AutoSubscribingEventListener {
                     event.getComment().getCreator(),
                     spaceContent,
                     () -> buildSimpleCommentNotification(
-                            content.getCreator(),
+                            event.getComment().getCreator(),
                             event.getComment().getBodyAsStringWithoutMarkup(),
                             spaceContent,
                             space));


### PR DESCRIPTION
I replaced line where Slack notification referred to the author of page with the line where it is correctly referred to the comment creator