### PR TITLE
When a branch/tag is deleted via "push" command respective subscription option is respected

### DIFF
--- a/bitbucket-slack-server-integration-plugin/src/main/java/com/atlassian/bitbucket/plugins/slack/listener/BitbucketNotificationEventListener.java
+++ b/bitbucket-slack-server-integration-plugin/src/main/java/com/atlassian/bitbucket/plugins/slack/listener/BitbucketNotificationEventListener.java
@@ -17,7 +17,10 @@ import com.atlassian.bitbucket.plugins.slack.notification.TaskNotificationTypes;
 import com.atlassian.bitbucket.plugins.slack.notification.configuration.PersonalNotificationService;
 import com.atlassian.bitbucket.plugins.slack.notification.renderer.SlackNotificationRenderer;
 import com.atlassian.bitbucket.pull.PullRequest;
+import com.atlassian.bitbucket.repository.RefChange;
+import com.atlassian.bitbucket.repository.RefChangeType;
 import com.atlassian.bitbucket.repository.Repository;
+import com.atlassian.bitbucket.repository.StandardRefType;
 import com.atlassian.bitbucket.user.ApplicationUser;
 import com.atlassian.event.api.EventListener;
 import com.atlassian.plugins.slack.api.notification.Verbosity;
@@ -141,13 +144,31 @@ public class BitbucketNotificationEventListener {
     @EventListener
     public void onEvent(final RepositoryRefsChangedEvent event) {
         RepositoryNotificationTypes.byEventClass(event.getClass()).ifPresent(notificationType ->
-                event.getRefChanges().forEach(refChange ->
-                        notificationPublisher.findChannelsAndPublishNotificationsAsync(
-                                event.getRepository(),
-                                notificationType.getKey(),
-                                Collections::emptySet,
-                                options -> ofNullable(slackNotificationRenderer.getPushMessage(
-                                        event, refChange, options.getVerbosity())))));
+                event.getRefChanges().forEach(refChange -> {
+                    // RepositoryRefsChangedEvent event is also triggered when branch/tag is deleted via push
+                    // replacing it here allows to respect 'branch/tag deleted' option in subscription settings
+                    RepositoryNotificationTypes correctedType = correctNotificationType(notificationType, refChange);
+
+                    notificationPublisher.findChannelsAndPublishNotificationsAsync(
+                            event.getRepository(),
+                            correctedType.getKey(),
+                            Collections::emptySet,
+                            options -> ofNullable(slackNotificationRenderer.getPushMessage(
+                                    event, refChange, options.getVerbosity())));
+                }));
+    }
+
+    private RepositoryNotificationTypes correctNotificationType(final RepositoryNotificationTypes currentType,
+                                                                final RefChange refChange) {
+        RepositoryNotificationTypes correctedType = currentType;
+        if (currentType == RepositoryNotificationTypes.PUSHED
+                && refChange.getType() == RefChangeType.DELETE) {
+            correctedType = refChange.getRef().getType() == StandardRefType.BRANCH
+                    ? RepositoryNotificationTypes.BRANCH_DELETED
+                    : RepositoryNotificationTypes.TAG_DELETED;
+        }
+
+        return correctedType;
     }
 
     @EventListener

--- a/bitbucket-slack-server-integration-plugin/src/test/java/com/atlassian/bitbucket/plugins/slack/listener/BitbucketNotificationEventListenerTest.java
+++ b/bitbucket-slack-server-integration-plugin/src/test/java/com/atlassian/bitbucket/plugins/slack/listener/BitbucketNotificationEventListenerTest.java
@@ -45,8 +45,11 @@ import com.atlassian.bitbucket.plugins.slack.notification.TaskNotificationTypes;
 import com.atlassian.bitbucket.plugins.slack.notification.renderer.SlackNotificationRenderer;
 import com.atlassian.bitbucket.pull.PullRequest;
 import com.atlassian.bitbucket.pull.PullRequestRef;
+import com.atlassian.bitbucket.repository.MinimalRef;
 import com.atlassian.bitbucket.repository.RefChange;
+import com.atlassian.bitbucket.repository.RefChangeType;
 import com.atlassian.bitbucket.repository.Repository;
+import com.atlassian.bitbucket.repository.StandardRefType;
 import com.atlassian.bitbucket.task.Task;
 import com.atlassian.bitbucket.task.TaskAnchor;
 import com.atlassian.bitbucket.task.TaskAnchorVisitor;
@@ -169,6 +172,8 @@ class BitbucketNotificationEventListenerTest {
     private RefChange refChange;
     @Mock
     private ApplicationUser user;
+    @Mock
+    private MinimalRef minimalRef;
 
     @Captor
     private ArgumentCaptor<Function<NotificationRenderingOptions, Optional<ChatPostMessageRequestBuilder>>> captor;
@@ -408,6 +413,46 @@ class BitbucketNotificationEventListenerTest {
         verify(notificationPublisher).findChannelsAndPublishNotificationsAsync(
                 same(repository),
                 eq(RepositoryNotificationTypes.PUSHED.getKey()),
+                any(),
+                captor.capture());
+
+        captor.getValue().apply(extendedOptions);
+        verify(slackNotificationRenderer).getPushMessage(repositoryPushEvent, refChange, Verbosity.EXTENDED);
+    }
+
+    @Test
+    void onEvent_repositoryPushBranchDeletedEvent_notificationTypeShouldBeFixed() {
+        when(repositoryPushEvent.getRepository()).thenReturn(repository);
+        when(repositoryPushEvent.getRefChanges()).thenReturn(Collections.singleton(refChange));
+        when(refChange.getType()).thenReturn(RefChangeType.DELETE);
+        when(refChange.getRef()).thenReturn(minimalRef);
+        when(minimalRef.getType()).thenReturn(StandardRefType.BRANCH);
+
+        target.onEvent(repositoryPushEvent);
+
+        verify(notificationPublisher).findChannelsAndPublishNotificationsAsync(
+                same(repository),
+                eq(RepositoryNotificationTypes.BRANCH_DELETED.getKey()),
+                any(),
+                captor.capture());
+
+        captor.getValue().apply(extendedOptions);
+        verify(slackNotificationRenderer).getPushMessage(repositoryPushEvent, refChange, Verbosity.EXTENDED);
+    }
+
+    @Test
+    void onEvent_repositoryPushTagDeletedEvent_notificationTypeShouldBeFixed() {
+        when(repositoryPushEvent.getRepository()).thenReturn(repository);
+        when(repositoryPushEvent.getRefChanges()).thenReturn(Collections.singleton(refChange));
+        when(refChange.getType()).thenReturn(RefChangeType.DELETE);
+        when(refChange.getRef()).thenReturn(minimalRef);
+        when(minimalRef.getType()).thenReturn(StandardRefType.TAG);
+
+        target.onEvent(repositoryPushEvent);
+
+        verify(notificationPublisher).findChannelsAndPublishNotificationsAsync(
+                same(repository),
+                eq(RepositoryNotificationTypes.TAG_DELETED.getKey()),
                 any(),
                 captor.capture());
 


### PR DESCRIPTION
It's not an app bug in fact, just an unexpected behaviour of Bitbucket. Replaced notification type is used in the query to the database, so corrected notification type allows to match event against correct event name.