### PR TITLE
Added organization tag to POM files

### DIFF
--- a/bitbucket-slack-server-integration-plugin/pom.xml
+++ b/bitbucket-slack-server-integration-plugin/pom.xml
@@ -10,6 +10,11 @@
     <name>Slack for Bitbucket Server</name>
     <description>This is the Slack integration for Bitbucket Server</description>
 
+    <organization>
+        <name>Atlassian</name>
+        <url>https://www.atlassian.com/</url>
+    </organization>
+
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,11 @@
     <packaging>pom</packaging>
     <name>Atlassian Slack Integration for Server Project</name>
 
+    <organization>
+        <name>Atlassian</name>
+        <url>https://www.atlassian.com/</url>
+    </organization>
+
     <modules>
         <module>slack-server-integration-common</module>
         <module>jira-slack-server-integration</module>


### PR DESCRIPTION
After removal of the parent project from POMs organization information was lost. I added it back explicitly.