### PR TITLE
Jira 9.x compatibility

### DIFF
--- a/.github/workflows/all-tests.yml
+++ b/.github/workflows/all-tests.yml
@@ -58,7 +58,7 @@ jobs:
     strategy:
       matrix:
         java-version: [8, 11]
-        jira-version: [8.1.0, 8.15.0]
+        jira-version: [8.9.0, 9.0.0-m0008]
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # Atlassian Server Integrations for Slack
 
 [![Atlassian license](https://img.shields.io/badge/license-Apache%202.0-blue.svg?style=flat-square)](LICENSE) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](CONTRIBUTING.md)
@@ -13,8 +14,8 @@ or by manually downloading plugin JAR files from Marketplace pages for [Jira](ht
 or [Bitbucket](https://marketplace.atlassian.com/apps/1220729/bitbucket-server-for-slack-official?hosting=server&tab=overview) plugins.
 Links to the official documentation are specified on Marketplace pages.
 
-Supported products (on 3 Feb, 2022). See [EOL policy](https://confluence.atlassian.com/support/atlassian-support-end-of-life-policy-201851003.html).
-* Jira: 8.1.0 (EOL 11 Feb, 2021) JDK 8, 11 - 8.15.0 (EOL 2 Feb 2023) on JDK 8, 11.
+Supported products (on 22 Mar, 2022). See [EOL policy](https://confluence.atlassian.com/support/atlassian-support-end-of-life-policy-201851003.html).
+* Jira: 8.9.0 (EOL 20 May, 2022) JDK 8, 11 - 9.0.0-m0008 (EOL TBD - start of 2024) on JDK 8, 11.
 * Confluence: 7.4.14 (EOL date: Apr 21, 2022) JDK 8, 11 - 7.15.0 (EOL date: Nov 24, 2023) JDK 8, 11.
 * Bitbucket: 7.0.0 (EOL date: 5 March 2022) on JDK 8, 11 - 7.21.0 (EOL date: 2 March 2024) on JDK 8, 11.
 

--- a/bin/build/run-jira-its.sh
+++ b/bin/build/run-jira-its.sh
@@ -2,13 +2,6 @@
 set -ex
 trap 'set +ex' EXIT
 
-TOMCAT_VERSION=${TOMCAT_VERSION:-tomcat8x}
-
-# Support Jira 8
-if [[ ${VERSION} == 8* ]] ; then
-    TESTKIT_VERSION=${TESTKIT_VERSION:-8.1.28}
-fi
-
 # Version less than or equal
 # https://stackoverflow.com/a/4024263
 verlte() {
@@ -17,6 +10,7 @@ verlte() {
 
 VERSION_ARG=$([[ -z ${VERSION} ]] && echo "" || echo "-Djira.version=${VERSION} -Dproduct.version=${VERSION}")
 TESTKIT_VERSION_ARG=$([[ -z ${TESTKIT_VERSION} ]] && echo "" || echo "-Dtestkit.version=${TESTKIT_VERSION}")
+CONTAINER_VERSION_ARG=$([[ -z ${CONTAINER_VERSION} ]] && echo "" || echo "-Dcontainer=${TESTKIT_VERSION}")
 # override Selenium version for Jira versions starting with 8.17.1
 SELENIUM_VERSION_ARG=$([[ -z ${VERSION} ]] || verlte ${VERSION} '8.17.0' && echo "" || echo "-Datlassian.selenium.version=3.2.4")
 
@@ -30,9 +24,9 @@ atlas-mvn --batch-mode verify \
   ${VERSION_ARG} \
   ${TESTKIT_VERSION_ARG} \
   ${SELENIUM_VERSION_ARG} \
+  ${CONTAINER_VERSION_ARG} \
   -Dut.test.skip=true \
   -Dit.test.skip=false \
-  -Dcontainer=${TOMCAT_VERSION} \
   -Dxvfb.enable=${XVFB_ENABLE:-true} \
   -Datlassian.plugins.enable.wait=300 \
   -Dserver=${HOST_NAME:-localhost} \

--- a/bitbucket-slack-server-integration-plugin/pom.xml
+++ b/bitbucket-slack-server-integration-plugin/pom.xml
@@ -10,6 +10,11 @@
     <name>Slack for Bitbucket Server</name>
     <description>This is the Slack integration for Bitbucket Server</description>
 
+    <organization>
+        <name>Atlassian</name>
+        <url>https://www.atlassian.com/</url>
+    </organization>
+
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/bitbucket-slack-server-integration-plugin/src/main/java/com/atlassian/bitbucket/plugins/slack/model/ExtendedChannelToNotify.java
+++ b/bitbucket-slack-server-integration-plugin/src/main/java/com/atlassian/bitbucket/plugins/slack/model/ExtendedChannelToNotify.java
@@ -1,10 +1,15 @@
 package com.atlassian.bitbucket.plugins.slack.model;
 
+import com.atlassian.bitbucket.user.ApplicationUser;
 import com.atlassian.plugins.slack.api.notification.ChannelToNotify;
 import lombok.Value;
+
+import javax.annotation.Nullable;
 
 @Value
 public class ExtendedChannelToNotify {
     ChannelToNotify channel;
     String notificationKey;
+    @Nullable
+    ApplicationUser applicationUser;
 }

--- a/bitbucket-slack-server-integration-plugin/src/main/java/com/atlassian/bitbucket/plugins/slack/model/NotificationRenderingOptions.java
+++ b/bitbucket-slack-server-integration-plugin/src/main/java/com/atlassian/bitbucket/plugins/slack/model/NotificationRenderingOptions.java
@@ -1,10 +1,15 @@
 package com.atlassian.bitbucket.plugins.slack.model;
 
+import com.atlassian.bitbucket.user.ApplicationUser;
 import com.atlassian.plugins.slack.api.notification.Verbosity;
 import lombok.Value;
+
+import javax.annotation.Nullable;
 
 @Value
 public class NotificationRenderingOptions {
     Verbosity verbosity;
     boolean isPersonal;
+    @Nullable
+    ApplicationUser applicationUser;
 }

--- a/bitbucket-slack-server-integration-plugin/src/main/java/com/atlassian/bitbucket/plugins/slack/notification/BitbucketPersonalNotificationTypes.java
+++ b/bitbucket-slack-server-integration-plugin/src/main/java/com/atlassian/bitbucket/plugins/slack/notification/BitbucketPersonalNotificationTypes.java
@@ -18,7 +18,7 @@ public enum BitbucketPersonalNotificationTypes {
      */
     PR_REVIEWER_CREATED,
     /**
-     * Tell me about all updates in a PR I’m a reviewer
+     * Tell me about all updates in a PR I’m a reviewer of
      */
     PR_REVIEWER_UPDATED
 }

--- a/bitbucket-slack-server-integration-plugin/src/main/java/com/atlassian/bitbucket/plugins/slack/notification/NotificationPublisher.java
+++ b/bitbucket-slack-server-integration-plugin/src/main/java/com/atlassian/bitbucket/plugins/slack/notification/NotificationPublisher.java
@@ -68,7 +68,7 @@ public class NotificationPublisher {
             final Verbosity verbosity = bitbucketSlackSettingsService.getVerbosity(
                     repository.getId(), channelToNotify.getTeamId(), channelToNotify.getChannelId());
             messageProvider
-                    .apply(new NotificationRenderingOptions(verbosity, channelToNotify.isPersonal()))
+                    .apply(new NotificationRenderingOptions(verbosity, channelToNotify.isPersonal(), channel.getApplicationUser()))
                     .ifPresent(message -> {
                         AnalyticsContext context = analyticsContextProvider.byTeamId(channelToNotify.getTeamId());
                         eventPublisher.publish(new BitbucketNotificationSentEvent(context, channel.getNotificationKey(),
@@ -86,7 +86,7 @@ public class NotificationPublisher {
                 .build();
         Set<ChannelToNotify> channels = notificationConfigurationService.getChannelsToNotify(request);
         return channels.stream()
-                .map(channel -> new ExtendedChannelToNotify(channel, notificationTypeKey))
+                .map(channel -> new ExtendedChannelToNotify(channel, notificationTypeKey, null))
                 .collect(Collectors.toSet());
     }
 

--- a/bitbucket-slack-server-integration-plugin/src/main/java/com/atlassian/bitbucket/plugins/slack/notification/renderer/SlackNotificationRenderer.java
+++ b/bitbucket-slack-server-integration-plugin/src/main/java/com/atlassian/bitbucket/plugins/slack/notification/renderer/SlackNotificationRenderer.java
@@ -317,17 +317,14 @@ public class SlackNotificationRenderer {
         return standardBlockMessage(text);
     }
 
-    public ChatPostMessageRequestBuilder getReviewersPullRequestMessage(
-            final PullRequestReviewersUpdatedEvent event,
-            final boolean isVerbose) {
-        final PullRequest pullRequest = event.getPullRequest();
+    public ChatPostMessageRequestBuilder getReviewersPullRequestMessage(final PullRequest pullRequest,
+                                                                        final ApplicationUser actor,
+                                                                        final boolean hasUserJoinedPr,
+                                                                        final boolean isVerbose) {
         final PullRequestRef toRef = pullRequest.getToRef();
         final Repository repository = toRef.getRepository();
-        final ApplicationUser actor = event.getUser();
-        final Collection<ApplicationUser> addedReviewers = ObjectUtils.firstNonNull(event.getAddedReviewers(), emptyList());
-        final boolean isOneUserAdded = addedReviewers.size() == 1;
 
-        final String suffix = isOneUserAdded ? "joined" : "removed";
+        final String suffix = hasUserJoinedPr ? "joined" : "removed";
         final String verboseSuffix = isVerbose ? ".long" : ".short";
         final String text = i18nResolver.getText(
                 "slack.activity.pr.reviewers." + suffix + verboseSuffix,

--- a/bitbucket-slack-server-integration-plugin/src/test/java/com/atlassian/bitbucket/plugins/slack/listener/BitbucketNotificationEventListenerTest.java
+++ b/bitbucket-slack-server-integration-plugin/src/test/java/com/atlassian/bitbucket/plugins/slack/listener/BitbucketNotificationEventListenerTest.java
@@ -162,7 +162,7 @@ class BitbucketNotificationEventListenerTest {
     @InjectMocks
     private BitbucketNotificationEventListener target;
 
-    private NotificationRenderingOptions extendedOptions = new NotificationRenderingOptions(Verbosity.EXTENDED, false);
+    private NotificationRenderingOptions extendedOptions = new NotificationRenderingOptions(Verbosity.EXTENDED, false, null);
 
     private void testPullRequestBlockerCommentEvent(PullRequestCommentEvent event, TaskNotificationTypes type) {
         when(event.getComment()).thenReturn(comment);
@@ -234,7 +234,7 @@ class BitbucketNotificationEventListenerTest {
         testPullRequestEvent(event, type, "PR title", reviewers);
     }
 
-    void testPullRequestEvent(PullRequestEvent event, PullRequestNotificationTypes type, String prTitle, boolean reviewers) {
+    void testPullRequestEvent(PullRequestEvent event, PullRequestNotificationTypes type, String prTitle, boolean isReviewersUpdate) {
         when(event.getPullRequest()).thenReturn(pullRequest);
         when(pullRequest.getTitle()).thenReturn(prTitle);
         when(pullRequest.getToRef()).thenReturn(pullRequestRef);
@@ -250,8 +250,8 @@ class BitbucketNotificationEventListenerTest {
                 captor.capture());
 
         captor.getValue().apply(extendedOptions);
-        if (reviewers) {
-            verify(slackNotificationRenderer).getReviewersPullRequestMessage((PullRequestReviewersUpdatedEvent) event, true);
+        if (isReviewersUpdate) {
+            verify(slackNotificationRenderer).getReviewersPullRequestMessage(pullRequest, user, true, true);
         } else {
             verify(slackNotificationRenderer).getPullRequestMessage(event);
         }

--- a/bitbucket-slack-server-integration-plugin/src/test/java/com/atlassian/bitbucket/plugins/slack/notification/configuration/PersonalNotificationServiceTest.java
+++ b/bitbucket-slack-server-integration-plugin/src/test/java/com/atlassian/bitbucket/plugins/slack/notification/configuration/PersonalNotificationServiceTest.java
@@ -123,7 +123,7 @@ public class PersonalNotificationServiceTest {
         Set<ExtendedChannelToNotify> channels = target.findNotificationsFor(currentUser, commitDiscussion);
 
         assertThat(channels, contains(new ExtendedChannelToNotify(new ChannelToNotify(TEAM_ID, SLACK_USER_ID, null, true),
-                "commit_author_comment")));
+                "commit_author_comment", commitAuthor)));
     }
 
     @Test
@@ -143,10 +143,10 @@ public class PersonalNotificationServiceTest {
         when(slackUser.getSlackUserId()).thenReturn(SLACK_USER_ID);
         when(watcherService.search(any(), any())).thenReturn(new PageImpl<>(new PageRequestImpl(0, 10), Collections.emptySet(), true));
 
-        Set<ExtendedChannelToNotify> channels = target.findNotificationsFor(currentUser, pullRequest, Collections.emptySet(), false);
+        Set<ExtendedChannelToNotify> channels = target.findNotificationsFor(currentUser, pullRequest, Collections.emptySet());
 
         assertThat(channels, contains(new ExtendedChannelToNotify(new ChannelToNotify(TEAM_ID, SLACK_USER_ID, null, true),
-                "pr_author")));
+                "pr_author", authorUser)));
     }
 
     @Test
@@ -168,10 +168,10 @@ public class PersonalNotificationServiceTest {
         when(slackUser.getUserToken()).thenReturn("someUserToken");
         when(slackUser.getSlackUserId()).thenReturn(SLACK_USER_ID);
 
-        Set<ExtendedChannelToNotify> channels = target.findNotificationsFor(currentUser, pullRequest, Collections.emptySet(), false);
+        Set<ExtendedChannelToNotify> channels = target.findNotificationsFor(currentUser, pullRequest, Collections.emptySet());
 
         assertThat(channels, contains(new ExtendedChannelToNotify(new ChannelToNotify(TEAM_ID, SLACK_USER_ID, null, true),
-                "pr_watcher")));
+                "pr_watcher", watcherUser)));
     }
 
     @Test
@@ -193,10 +193,10 @@ public class PersonalNotificationServiceTest {
         when(slackUser.getUserToken()).thenReturn("someUserToken");
         when(slackUser.getSlackUserId()).thenReturn(SLACK_USER_ID);
 
-        Set<ExtendedChannelToNotify> channels = target.findNotificationsFor(currentUser, pullRequest, Collections.emptySet(), true);
+        Set<ExtendedChannelToNotify> channels = target.findNotificationsFor(currentUser, pullRequest, Collections.singleton(reviewerUser));
 
         assertThat(channels, contains(new ExtendedChannelToNotify(new ChannelToNotify(TEAM_ID, SLACK_USER_ID, null, true),
-                "pr_reviewer_created")));
+                "pr_reviewer_created", reviewerUser)));
     }
 
     @Test
@@ -218,9 +218,9 @@ public class PersonalNotificationServiceTest {
         when(slackUser.getUserToken()).thenReturn("someUserToken");
         when(slackUser.getSlackUserId()).thenReturn(SLACK_USER_ID);
 
-        Set<ExtendedChannelToNotify> channels = target.findNotificationsFor(currentUser, pullRequest, Collections.emptySet(), false);
+        Set<ExtendedChannelToNotify> channels = target.findNotificationsFor(currentUser, pullRequest, Collections.emptySet());
 
         assertThat(channels, contains(new ExtendedChannelToNotify(new ChannelToNotify(TEAM_ID, SLACK_USER_ID, null, true),
-                "pr_reviewer_updated")));
+                "pr_reviewer_updated", reviewerUser)));
     }
 }

--- a/bitbucket-slack-server-integration-plugin/src/test/java/com/atlassian/bitbucket/plugins/slack/notification/renderer/SlackNotificationRendererTest.java
+++ b/bitbucket-slack-server-integration-plugin/src/test/java/com/atlassian/bitbucket/plugins/slack/notification/renderer/SlackNotificationRendererTest.java
@@ -516,7 +516,7 @@ public class SlackNotificationRendererTest {
         when(pullRequestReviewersUpdatedEvent.getUser()).thenReturn(user);
         when(pullRequestReviewersUpdatedEvent.getAddedReviewers()).thenReturn(Collections.singleton(user));
 
-        ChatPostMessageRequest result = renderer.getReviewersPullRequestMessage(pullRequestReviewersUpdatedEvent, true).build();
+        ChatPostMessageRequest result = renderer.getReviewersPullRequestMessage(pullRequest, user, true, true).build();
 
         assertMessage(result, join("slack.activity.pr.reviewers.joined.long", USER_SLACK_LINK, PR_SLACK_LINK, REPO_SLACK_LINK,
                 PR_FROM_BRANCH_LINK, PR_TO_BRANCH_LINK));
@@ -528,7 +528,7 @@ public class SlackNotificationRendererTest {
         when(pullRequestReviewersUpdatedEvent.getUser()).thenReturn(user);
         when(pullRequestReviewersUpdatedEvent.getRemovedReviewers()).thenReturn(Collections.singleton(user));
 
-        ChatPostMessageRequest result = renderer.getReviewersPullRequestMessage(pullRequestReviewersUpdatedEvent, false).build();
+        ChatPostMessageRequest result = renderer.getReviewersPullRequestMessage(pullRequest, user, false, false).build();
 
         assertMessage(result, join("slack.activity.pr.reviewers.removed.short", USER_SLACK_LINK, PR_SLACK_LINK, REPO_SLACK_LINK,
                 PR_FROM_BRANCH_LINK, PR_TO_BRANCH_LINK));

--- a/confluence-slack-server-integration-plugin/pom.xml
+++ b/confluence-slack-server-integration-plugin/pom.xml
@@ -31,6 +31,12 @@
         <dependency>
             <groupId>com.atlassian.plugins</groupId>
             <artifactId>slack-server-integration-common</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.atlassian.selenium</groupId>
+                    <artifactId>atlassian-pageobjects-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Slack -->
@@ -199,11 +205,17 @@
             <groupId>com.atlassian.plugins</groupId>
             <artifactId>slack-server-integration-test-common</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.atlassian.selenium</groupId>
+                    <artifactId>atlassian-webdriver-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.atlassian.confluence</groupId>
             <artifactId>confluence-webdriver-pageobjects</artifactId>
-            <version>9.0.12</version>
+            <version>11.4.5</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -219,6 +231,12 @@
         <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>${slf4j.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/confluence-slack-server-integration-plugin/src/test/java/it/com/atlassian/confluence/plugins/slack/pageobjects/MappingRow.java
+++ b/confluence-slack-server-integration-plugin/src/test/java/it/com/atlassian/confluence/plugins/slack/pageobjects/MappingRow.java
@@ -33,9 +33,12 @@ public class MappingRow extends ConfluenceAbstractPageComponent {
 
     public void clickTrashButton() {
         container.find(By.className("trash-channel-mapping")).click();
+
         final Dialog2 dialog = pageBinder.bind(Dialog2.class, "slack-remove-mapping-dialog");
-        Poller.waitUntilTrue(getConfirmButton(dialog).timed().isVisible());
-        getConfirmButton(dialog).click();
+        final PageElement confirmButton = getConfirmButton(dialog);
+
+        Poller.waitUntilTrue(confirmButton.timed().isVisible());
+        confirmButton.click();
     }
 
     private PageElement getConfirmButton(Dialog2 dialog) {

--- a/confluence-slack-server-integration-plugin/src/test/java/it/com/atlassian/confluence/plugins/slack/pageobjects/SpaceConfigurationPage.java
+++ b/confluence-slack-server-integration-plugin/src/test/java/it/com/atlassian/confluence/plugins/slack/pageobjects/SpaceConfigurationPage.java
@@ -3,6 +3,7 @@ package it.com.atlassian.confluence.plugins.slack.pageobjects;
 import com.atlassian.confluence.webdriver.pageobjects.page.ConfluenceAbstractPage;
 import com.atlassian.pageobjects.elements.ElementBy;
 import com.atlassian.pageobjects.elements.PageElement;
+import com.atlassian.pageobjects.elements.query.Poller;
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
 
@@ -46,5 +47,9 @@ public class SpaceConfigurationPage extends ConfluenceAbstractPage {
     @Override
     public String getUrl() {
         return "/spaces/slack2.action?key=" + spaceKey + "&teamId=" + teamId;
+    }
+
+    public void waitForPageToBeLoaded() {
+        Poller.waitUntilTrue("Configuration page failed to load", configurationSection.timed().isVisible());
     }
 }

--- a/confluence-slack-server-integration-plugin/src/test/java/it/com/atlassian/confluence/plugins/slack/util/SlackFunctionalTestBase.java
+++ b/confluence-slack-server-integration-plugin/src/test/java/it/com/atlassian/confluence/plugins/slack/util/SlackFunctionalTestBase.java
@@ -40,7 +40,10 @@ public abstract class SlackFunctionalTestBase {
 
     @RegisterExtension
     protected static SlackMockServerExtension server = new SlackMockServerExtension(
-            () -> Collections.singleton(client.instance().getBaseUrl()), testNameProvider);
+            () -> {
+                String baseUrl = client.instance().getBaseUrl();
+                return Collections.singleton(baseUrl);
+            }, testNameProvider);
 
     public static final String SPACE_KEY = "IT";
 

--- a/confluence-slack-server-integration-plugin/src/test/java/it/com/atlassian/confluence/plugins/slack/util/SlackWebTestBase.java
+++ b/confluence-slack-server-integration-plugin/src/test/java/it/com/atlassian/confluence/plugins/slack/util/SlackWebTestBase.java
@@ -1,13 +1,24 @@
 package it.com.atlassian.confluence.plugins.slack.util;
 
 import com.atlassian.pageobjects.ProductInstance;
+import com.atlassian.pageobjects.elements.query.Conditions;
+import com.atlassian.pageobjects.elements.query.Poller;
 import com.atlassian.plugins.slack.test.RuleAdaptorExtension;
 import com.atlassian.webdriver.testing.annotation.WindowSize;
 import com.atlassian.webdriver.testing.rule.SessionCleanupRule;
 import com.atlassian.webdriver.testing.rule.WebDriverScreenshotRule;
 import com.atlassian.webdriver.testing.rule.WindowSizeRule;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
 
+import java.util.List;
+
+@Slf4j
 @WindowSize(width = 1260, height = 768)
 public abstract class SlackWebTestBase extends SlackFunctionalTestBase {
     @RegisterExtension
@@ -24,7 +35,41 @@ public abstract class SlackWebTestBase extends SlackFunctionalTestBase {
     @RegisterExtension
     static RuleAdaptorExtension webDriverScreenshotRule = new RuleAdaptorExtension(new WebDriverScreenshotRule());
 
-    protected void closeAuiFlags() {
-        confluence.get().getTester().getDriver().executeScript("AJS.$('.aui-flag').each(function(it) { this.close(); } );");
+    protected void closeAuiFlags(final long sleepMsBeforeChecking) {
+        try {
+            Thread.sleep(sleepMsBeforeChecking);
+        } catch (InterruptedException e) {
+            throw new RuntimeException("Waiting before AUI flags check failed", e);
+        }
+
+        WebDriver driver = confluence.get().getTester().getDriver();
+        List<WebElement> flags = driver.findElements(By.className("aui-flag"));
+        log.debug("{} open AUI flags found", flags.size());
+
+        if (flags.isEmpty()) {
+            return;
+        }
+
+        // attempt #1. try to close them using JS. doesn't work sometimes for unknown reasons
+        JavascriptExecutor executor = (JavascriptExecutor) driver;
+        executor.executeScript("AJS.$('.aui-flag').each(function(it) { this.close(); } );");
+
+        // attempt #2. click on flag 'close' buttons
+        flags = driver.findElements(By.className("aui-flag"));
+        for (WebElement flag : flags) {
+            try {
+                flag.findElement(By.className("aui-close-button")).click();
+            } catch (NoSuchElementException e) {
+                // ignore intentionally; the flag is already closed
+            }
+        }
+
+        // verify that all of them were closed
+        for (int i = 0; i < flags.size(); i++) {
+            WebElement flag = flags.get(i);
+            Poller.waitUntilFalse("AUI flag failed to be closed", Conditions.forSupplier(5 * 1000, flag::isDisplayed));
+
+            log.debug("AUI flag #{} isn't displayed anymore", i);
+        }
     }
 }

--- a/confluence-slack-server-integration-plugin/src/test/java/it/com/atlassian/confluence/plugins/slack/web/ConfigurationWebTest.java
+++ b/confluence-slack-server-integration-plugin/src/test/java/it/com/atlassian/confluence/plugins/slack/web/ConfigurationWebTest.java
@@ -42,7 +42,7 @@ public class ConfigurationWebTest extends SlackWebTestBase {
     void addNewConfiguration() {
         final SpaceConfigurationPage configPage = confluence.loginAs(
                 UserWithDetails.ADMIN, SpaceConfigurationPage.class, SPACE_KEY, DUMMY_TEAM_ID);
-        closeAuiFlags();
+        closeAuiFlags(2 * 1000);
 
         assertThat(configPage.isLinked(), is(true));
         ConnectionStatus workspaceConnection = configPage.workspaceConnection();
@@ -84,7 +84,9 @@ public class ConfigurationWebTest extends SlackWebTestBase {
 
         final SpaceConfigurationPage configPage = confluence.loginAs(
                 UserWithDetails.ADMIN, SpaceConfigurationPage.class, SPACE_KEY, DUMMY_TEAM_ID);
-        closeAuiFlags();
+        configPage.waitForPageToBeLoaded();
+        configPage.dismissFlagMessages();
+        closeAuiFlags(2 * 1000);
 
         final ConfigurationSection configurationSection = configPage.geConfigurationSection();
         final Optional<MappingRow> mapping = findMappingRow(configurationSection.getMappingTable(), PUBLIC.getId());

--- a/confluence-slack-server-integration-plugin/src/test/resources/simplelogger.properties
+++ b/confluence-slack-server-integration-plugin/src/test/resources/simplelogger.properties
@@ -1,0 +1,5 @@
+org.slf4j.simpleLogger.defaultLogLevel=debug
+org.slf4j.simpleLogger.showDateTime=true
+
+org.slf4j.simpleLogger.log.com.atlassian=trace
+org.slf4j.simpleLogger.log.it.com.atlassian=trace

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/web/actions/MigrateToSlackAction.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/web/actions/MigrateToSlackAction.java
@@ -1,5 +1,7 @@
 package com.atlassian.jira.plugins.slack.web.actions;
 
+import com.atlassian.jira.security.request.RequestMethod;
+import com.atlassian.jira.security.request.SupportedMethods;
 import com.atlassian.jira.web.action.ActionViewDataMappings;
 import com.atlassian.jira.web.action.JiraWebActionSupport;
 import com.google.common.collect.ImmutableMap;
@@ -9,6 +11,7 @@ import java.util.Map;
 /**
  * Provides context for migrate to Slack channel selection dialog.
  */
+@SupportedMethods(RequestMethod.GET)
 public class MigrateToSlackAction extends JiraWebActionSupport {
     private String roomName;
 

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/web/actions/SlackConfigureProjectAction.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/web/actions/SlackConfigureProjectAction.java
@@ -8,6 +8,8 @@ import com.atlassian.jira.plugins.slack.model.dto.ProjectToChannelConfigurationD
 import com.atlassian.jira.plugins.slack.model.event.JiraPage;
 import com.atlassian.jira.project.Project;
 import com.atlassian.jira.projectconfig.util.ProjectConfigRequestCache;
+import com.atlassian.jira.security.request.RequestMethod;
+import com.atlassian.jira.security.request.SupportedMethods;
 import com.atlassian.jira.util.velocity.VelocityRequestContextFactory;
 import com.atlassian.jira.web.action.ActionViewDataMappings;
 import com.atlassian.plugins.slack.analytics.AnalyticsContextProvider;
@@ -28,6 +30,7 @@ import java.util.Optional;
 /**
  * Be careful when naming actions: https://jira.atlassian.com/browse/JRASERVER-26275
  */
+@SupportedMethods(RequestMethod.GET)
 public class SlackConfigureProjectAction extends AbstractProjectAction {
     public static final String JQL_HELP_URL_PARAM = "jqlHelpUrl";
     public static final String ADVANCED_SEARCH_HELP_KEY = "advanced_search";

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/web/actions/SlackEditGlobalSettings.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/web/actions/SlackEditGlobalSettings.java
@@ -1,16 +1,21 @@
 package com.atlassian.jira.plugins.slack.web.actions;
 
 import com.atlassian.jira.plugins.slack.manager.PluginConfigurationManager;
+import com.atlassian.jira.security.request.RequestMethod;
+import com.atlassian.jira.security.request.SupportedMethods;
 import com.atlassian.jira.web.action.ActionViewDataMappings;
 import com.atlassian.jira.web.action.JiraWebActionSupport;
 import com.atlassian.webresource.api.assembler.PageBuilderService;
 import com.google.common.collect.ImmutableMap;
+import lombok.RequiredArgsConstructor;
 
 import java.util.Map;
 
 /**
  * Page of advanced settings for global stuff
  */
+@SupportedMethods(RequestMethod.GET)
+@RequiredArgsConstructor
 public class SlackEditGlobalSettings extends JiraWebActionSupport {
     public static final String ALLOW_GLOBAL_AUTOCONVERT = "allowGlobalAutoConvert";
     public static final String ALLOW_AUTOCONVERT_FOR_GUEST_CHANNELS = "allowAutoConvertInGuestChannels";
@@ -18,12 +23,6 @@ public class SlackEditGlobalSettings extends JiraWebActionSupport {
 
     protected final PluginConfigurationManager pluginConfigurationManager;
     private final PageBuilderService pageBuilderService;
-
-    public SlackEditGlobalSettings(PluginConfigurationManager pluginConfigurationManager,
-                                   PageBuilderService pageBuilderService) {
-        this.pluginConfigurationManager = pluginConfigurationManager;
-        this.pageBuilderService = pageBuilderService;
-    }
 
     @ActionViewDataMappings({SUCCESS})
     public Map<String, Object> getDataMap() {

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/web/actions/SlackEditProjectSettings.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/web/actions/SlackEditProjectSettings.java
@@ -4,6 +4,8 @@ import com.atlassian.jira.plugins.slack.manager.PluginConfigurationManager;
 import com.atlassian.jira.plugins.slack.manager.ProjectConfigurationManager;
 import com.atlassian.jira.project.Project;
 import com.atlassian.jira.project.ProjectManager;
+import com.atlassian.jira.security.request.RequestMethod;
+import com.atlassian.jira.security.request.SupportedMethods;
 import com.atlassian.jira.web.action.ActionViewDataMappings;
 import com.atlassian.webresource.api.assembler.PageBuilderService;
 import com.google.common.collect.ImmutableMap;
@@ -17,6 +19,7 @@ import java.util.Map;
  * We edit the project settings from here There is a shared scope between EditProjectSettings and EditGlobalSettings so
  * it's better to inherit for later use
  */
+@SupportedMethods(RequestMethod.GET)
 public class SlackEditProjectSettings extends SlackEditGlobalSettings {
     private static final String PROJECT_KEY = "projectKey";
     private static final String ALLOW_PROJECT_AUTOCONVERT = "allowProjectAutoConvert";

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/web/actions/SlackIssueMentionsAction.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/web/actions/SlackIssueMentionsAction.java
@@ -9,6 +9,8 @@ import com.atlassian.jira.plugins.slack.model.mentions.IssueMentionViewResponseF
 import com.atlassian.jira.plugins.slack.model.mentions.MentionChannel;
 import com.atlassian.jira.plugins.slack.service.mentions.IssueMentionService;
 import com.atlassian.jira.security.PermissionManager;
+import com.atlassian.jira.security.request.RequestMethod;
+import com.atlassian.jira.security.request.SupportedMethods;
 import com.atlassian.jira.user.ApplicationUser;
 import com.atlassian.jira.web.action.ActionViewDataMappings;
 import com.atlassian.jira.web.action.JiraWebActionSupport;
@@ -22,6 +24,7 @@ import java.util.stream.Collectors;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 
+@SupportedMethods(RequestMethod.GET)
 @RequiredArgsConstructor
 public class SlackIssueMentionsAction extends JiraWebActionSupport {
     private final IssueMentionService issueMentionService;

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/web/actions/SlackSelectDedicatedChannelAction.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/web/actions/SlackSelectDedicatedChannelAction.java
@@ -2,6 +2,8 @@ package com.atlassian.jira.plugins.slack.web.actions;
 
 import com.atlassian.jira.issue.IssueManager;
 import com.atlassian.jira.issue.MutableIssue;
+import com.atlassian.jira.security.request.RequestMethod;
+import com.atlassian.jira.security.request.SupportedMethods;
 import com.atlassian.jira.web.action.ActionViewDataMappings;
 import com.atlassian.jira.web.action.JiraWebActionSupport;
 import com.atlassian.plugins.slack.api.client.SlackClient;
@@ -16,6 +18,7 @@ import java.util.stream.Collectors;
 /**
  * Provides context for dedicated channel selection dialog.
  */
+@SupportedMethods(RequestMethod.GET)
 public class SlackSelectDedicatedChannelAction extends JiraWebActionSupport {
     private final IssueManager issueManager;
     private final SlackLinkManager slackLinkManager;

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/web/rest/SlackMessageResource.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/web/rest/SlackMessageResource.java
@@ -42,6 +42,7 @@ import javax.ws.rs.core.Response;
 import java.sql.Timestamp;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import java.util.Set;
 
@@ -272,6 +273,16 @@ public class SlackMessageResource {
                     @Override
                     public boolean isArchived() {
                         return false;
+                    }
+
+                    @Override
+                    public ApplicationUser getArchivedBy() {
+                        return null;
+                    }
+
+                    @Override
+                    public Date getArchivedDate() {
+                        return null;
                     }
                 };
             }

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/test/java/it/com/atlassian/jira/plugins/slack/functional/SanityCheckFuncTest.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/test/java/it/com/atlassian/jira/plugins/slack/functional/SanityCheckFuncTest.java
@@ -2,6 +2,7 @@ package it.com.atlassian.jira.plugins.slack.functional;
 
 import com.atlassian.jira.functest.rule.SkipCacheCheck;
 import it.com.atlassian.jira.plugins.slack.util.SlackFunctionalTestBase;
+import okhttp3.Response;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -20,9 +21,10 @@ public class SanityCheckFuncTest extends SlackFunctionalTestBase {
 
     @Test
     public void openIssuePage() {
+        Response pageHtml = client.admin().visitPage("browse/PRO-1");
         assertThat(
-                client.admin().visitPage("browse/PRO-1"),
-                success(containsString("<title>[PRO-1] This is your first task - Super Jira</title>")));
+                pageHtml,
+                success(containsString("[PRO-1] This is your first task")));
     }
 
     @Test

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/test/java/it/com/atlassian/jira/plugins/slack/pageobjects/ChannelSelector.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/test/java/it/com/atlassian/jira/plugins/slack/pageobjects/ChannelSelector.java
@@ -30,11 +30,11 @@ public class ChannelSelector extends DropdownSelect {
         waitForChannelOption(channelName);
 
         // try and retry
-        pickOption(channelName);
+        pickOptionFixed(channelName);
         if (!isChannelSelected(channelName)) {
             // it's probably flakiness so let's try one more time
             flakyWait();
-            pickOption(channelName);
+            pickOptionFixed(channelName);
         }
         if (!isChannelSelected(channelName)) {
             // it's probably flakiness so let's fallback to set value directly
@@ -61,4 +61,18 @@ public class ChannelSelector extends DropdownSelect {
         }
     }
 
+    // fixed version of Atlassian-provided DropdownSelect.pickOption()
+    // it starts freezing in Jira 9.0
+    private void pickOptionFixed(String optionId) {
+        this.open();
+        By selector = By.cssSelector(String.format(".aui-list-item-li-%s", optionId));
+        this.activateSelection(selector);
+        this.getDropDownItem(selector).click();
+        this.waitForClose();
+    }
+
+    private void activateSelection(By by) {
+        PageElement selection = this.elementFinder.find(by);
+        this.actions.moveToElement(selection).moveByOffset(1, 0).perform();
+    }
 }

--- a/jira-slack-server-integration/pom.xml
+++ b/jira-slack-server-integration/pom.xml
@@ -22,8 +22,8 @@
         <aui.version>5.1.3</aui.version>
 
         <!-- this is the version we will run integration tests against -->
-        <jira.version>8.1.0</jira.version>
-        <testkit.version>8.1.0</testkit.version>
+        <jira.version>8.9.0</jira.version>
+        <testkit.version>8.1.45</testkit.version>
         <jira.test.unit.version>${jira.version}</jira.test.unit.version>
 
         <jira.webdriver.version>${jira.version}</jira.webdriver.version>
@@ -31,7 +31,7 @@
         <reactive.extension.version>1.0.0</reactive.extension.version>
 
         <!-- This is the version the plugin is compiled against -->
-        <jira.compile.version>8.1.0</jira.compile.version>
+        <jira.compile.version>9.0.0-m0008</jira.compile.version>
 
         <jira.pageobjects.version>${jira.version}</jira.pageobjects.version>
 

--- a/jira-slack-server-integration/pom.xml
+++ b/jira-slack-server-integration/pom.xml
@@ -22,13 +22,9 @@
         <aui.version>5.1.3</aui.version>
 
         <!-- this is the version we will run integration tests against -->
-        <jira.version>8.9.0</jira.version>
+        <jira.version>9.0.0-m0008</jira.version>
         <testkit.version>8.1.45</testkit.version>
         <jira.test.unit.version>${jira.version}</jira.test.unit.version>
-
-        <jira.webdriver.version>${jira.version}</jira.webdriver.version>
-        <atlassian.selenium.version>2.5.1-jira-1</atlassian.selenium.version>
-        <reactive.extension.version>1.0.0</reactive.extension.version>
 
         <!-- This is the version the plugin is compiled against -->
         <jira.compile.version>9.0.0-m0008</jira.compile.version>
@@ -38,7 +34,6 @@
         <jira.data.version>${jira.version}</jira.data.version>
         <jira-project-config.version>${jira.version}</jira-project-config.version>
         <triggers.version>2.3.8</triggers.version>
-        <selenium.version>2.41.0</selenium.version>
         <httpclient.version>0.15.0</httpclient.version>
         <httpclient-core.version>4.3.2</httpclient-core.version>
 
@@ -133,28 +128,6 @@
                 <artifactId>atlassian-jira-pageobjects</artifactId>
                 <version>${jira.pageobjects.version}</version>
             </dependency>
-
-            <!--<dependency>-->
-            <!--<groupId>org.seleniumhq.selenium</groupId>-->
-            <!--<artifactId>selenium-java</artifactId>-->
-            <!--<version>${selenium.version}</version>-->
-            <!--</dependency>-->
-            <!--<dependency>-->
-            <!--<groupId>org.seleniumhq.selenium</groupId>-->
-            <!--<artifactId>selenium-remote-driver</artifactId>-->
-            <!--<version>${selenium.version}</version>-->
-            <!--</dependency>-->
-            <!--<dependency>-->
-            <!--<groupId>com.atlassian.selenium</groupId>-->
-            <!--<artifactId>atlassian-selenium</artifactId>-->
-            <!--<version>${atlassian.selenium.version}</version>-->
-            <!--<exclusions>-->
-            <!--<exclusion>-->
-            <!--<groupId>org.seleniumhq.selenium</groupId>-->
-            <!--<artifactId>selenium-remote-driver</artifactId>-->
-            <!--</exclusion>-->
-            <!--</exclusions>-->
-            <!--</dependency>-->
             <dependency>
                 <groupId>com.atlassian.jira</groupId>
                 <artifactId>jira-tests</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,11 @@
     <packaging>pom</packaging>
     <name>Atlassian Slack Integration for Server Project</name>
 
+    <organization>
+        <name>Atlassian</name>
+        <url>https://www.atlassian.com/</url>
+    </organization>
+
     <modules>
         <module>slack-server-integration-common</module>
         <module>jira-slack-server-integration</module>

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,6 @@
 
         <webresource.version>3.5.39</webresource.version>
         <atlassian-cache.version>3.2.0</atlassian-cache.version>
-        <atlassian.selenium.version>2.6.1</atlassian.selenium.version>
 
         <slack.common.version>1.1.13</slack.common.version>
     </properties>
@@ -223,37 +222,6 @@
                 <groupId>javax.annotation</groupId>
                 <artifactId>javax.annotation-api</artifactId>
                 <version>1.3.2</version>
-            </dependency>
-            <dependency>
-                <groupId>com.atlassian.selenium</groupId>
-                <artifactId>atlassian-webdriver-core</artifactId>
-                <version>${atlassian.selenium.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>com.google.collections</groupId>
-                        <artifactId>google-collections</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <artifactId>jsr305</artifactId>
-                        <groupId>com.atlassian.bundles</groupId>
-                    </exclusion>
-                    <exclusion>
-                        <artifactId>fugue</artifactId>
-                        <groupId>com.atlassian.fugue</groupId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>com.google.collections</groupId>
-                        <artifactId>google-collections</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.seleniumhq.selenium</groupId>
-                        <artifactId>selenium-htmlunit-driver</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <artifactId>commons-lang</artifactId>
-                        <groupId>commons-lang</groupId>
-                    </exclusion>
-                </exclusions>
             </dependency>
             <dependency>
                 <groupId>com.atlassian.ozymandias</groupId>
@@ -501,28 +469,6 @@
                 <artifactId>atlassian-test-categories</artifactId>
                 <version>0.5</version>
                 <scope>test</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>com.atlassian.selenium</groupId>
-                <artifactId>atlassian-pageobjects-api</artifactId>
-                <version>${atlassian.selenium.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>com.atlassian.selenium</groupId>
-                <artifactId>atlassian-pageobjects-elements</artifactId>
-                <version>${atlassian.selenium.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.seleniumhq.selenium</groupId>
-                        <artifactId>selenium-java</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <artifactId>jsr305</artifactId>
-                        <groupId>com.atlassian.bundles</groupId>
-                    </exclusion>
-                </exclusions>
             </dependency>
 
             <dependency>

--- a/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/api/client/DefaultSlackClient.java
+++ b/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/api/client/DefaultSlackClient.java
@@ -280,13 +280,14 @@ public class DefaultSlackClient implements SlackClient {
         checkArgument(isNotBlank(code), "code cannot be null or empty");
 
         // https://api.slack.com/methods/oauth.access
-        return toEither("oauth.access/" + slackLink.getClientId(), () ->
+        Either<ErrorResponse, OAuthAccessResponse> result = toEither("oauth.access/" + slackLink.getClientId(), () ->
                 slackMethods.oauthAccess(OAuthAccessRequest.builder()
                         .code(code)
                         .redirectUri(redirectUri)
                         .clientId(slackLink.getClientId())
                         .clientSecret(slackLink.getClientSecret())
                         .build()));
+        return result;
     }
 
     // conversations

--- a/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/oauth2/DefaultOauth2AuthoriseService.java
+++ b/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/oauth2/DefaultOauth2AuthoriseService.java
@@ -93,15 +93,16 @@ public class DefaultOauth2AuthoriseService implements Oauth2AuthoriseService {
                             .queryParam("team", link.getTeamId())
                             .build();
 
-                    final UriBuilder originUri = UriBuilder.fromUri(applicationProperties.getBaseUrl(UrlMode.ABSOLUTE))
+                    final UriBuilder originUriBuilder = UriBuilder.fromUri(applicationProperties.getBaseUrl(UrlMode.ABSOLUTE))
                             .path(data.getRedirect())
                             .replaceQuery(data.getRedirectQuery());
                     if (StringUtils.isNotBlank(data.getFragment())) {
-                        originUri.fragment(data.getFragment());
+                        originUriBuilder.fragment(data.getFragment());
                     }
 
                     final HttpSession session = data.getServletRequest().getSession();
-                    session.setAttribute(data.getSecret() + "-origin-url", originUri.build().toString());
+                    final String originUrl = originUriBuilder.build().toString();
+                    session.setAttribute(data.getSecret() + "-origin-url", originUrl);
 
                     eventPublisher.publish(new OauthFlowEvent(analyticsContextProvider.bySlackLink(link), Status.STARTED));
 

--- a/slack-server-integration-test-common/pom.xml
+++ b/slack-server-integration-test-common/pom.xml
@@ -12,6 +12,10 @@
     <artifactId>slack-server-integration-test-common</artifactId>
     <name>Integration Tests Common module</name>
 
+    <properties>
+        <atlassian.selenium.version>3.2.6</atlassian.selenium.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.atlassian.plugins</groupId>
@@ -37,21 +41,63 @@
             <artifactId>spring-beans</artifactId>
             <scope>provided</scope>
         </dependency>
+
+        <!-- Selenium dependencies -->
+        <dependency>
+            <groupId>com.atlassian.selenium</groupId>
+            <artifactId>atlassian-webdriver-core</artifactId>
+            <version>${atlassian.selenium.version}</version>
+            <scope>compile</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.collections</groupId>
+                    <artifactId>google-collections</artifactId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>jsr305</artifactId>
+                    <groupId>com.atlassian.bundles</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>fugue</artifactId>
+                    <groupId>com.atlassian.fugue</groupId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.collections</groupId>
+                    <artifactId>google-collections</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.seleniumhq.selenium</groupId>
+                    <artifactId>selenium-htmlunit-driver</artifactId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>commons-lang</artifactId>
+                    <groupId>commons-lang</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
         <dependency>
             <groupId>com.atlassian.selenium</groupId>
             <artifactId>atlassian-pageobjects-api</artifactId>
+            <version>${atlassian.selenium.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.atlassian.selenium</groupId>
             <artifactId>atlassian-pageobjects-elements</artifactId>
+            <version>${atlassian.selenium.version}</version>
             <scope>compile</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.seleniumhq.selenium</groupId>
+                    <artifactId>selenium-java</artifactId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>jsr305</artifactId>
+                    <groupId>com.atlassian.bundles</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
-        <dependency>
-            <groupId>com.atlassian.selenium</groupId>
-            <artifactId>atlassian-webdriver-core</artifactId>
-            <scope>compile</scope>
-        </dependency>
+
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>mockwebserver</artifactId>

--- a/slack-server-integration-test-common/src/main/java/com/atlassian/plugins/slack/test/mockserver/SlackMockServer.java
+++ b/slack-server-integration-test-common/src/main/java/com/atlassian/plugins/slack/test/mockserver/SlackMockServer.java
@@ -166,8 +166,9 @@ public class SlackMockServer {
     private class MockDispatcher extends Dispatcher {
         @Override
         public MockResponse dispatch(final RecordedRequest request) {
+            final String body = request.getBody().readUtf8();
             final RequestHistoryItem historyItem = new RequestHistoryItem(
-                    request, replaceRegularAndEncodedBaseUrl(request.getBody().readUtf8()));
+                    request, replaceRegularAndEncodedBaseUrl(body));
             final boolean isOauthAccess = "oauth.access".equals(historyItem.apiMethod());
             final String reqTag = defaultString(historyItem.tag());
 


### PR DESCRIPTION
New Jira major upgrade brought a lot of breaking changes, so it is expected that some of them affected Slack plugin. The changes are listed here: https://confluence.atlassian.com/jiracore/preparing-for-jira-9-0-1115661092.html
This PR contains:
1. New `@SupportedMethods` annotations on Webwork actions, that define supported HTTP methods. If an action doesn't contain this annotation, only POST requests are allowed. That's why some actions weren't annotated.
2. The page title was updated in`SanityCheckFuncTest` because Jira 9.x uses lazy loading of issue details and it appeared that window tab title belongs to that set of dynamically populated information. It is set to an issue description via Javascript, that isn't run when the test code loads an issue page.
3. `@SupportedMethods` annotation is not available in versions of `jira-api` dependency older than 9.x, so I upgraded it to `9.0.0-m0008` and updated the range of supported Jira versions in CI config to use it as well.
4. The change made in step 3 broke integration tests and caused further changes in root module `pom.xml`. It led to restructure of Selenium and Page Objects related dependencies in other modules too.
5. Other minor changes were added to easy the debug process.