### PR TITLE
Added a proper handling of advanced setting saving errors and an abil…

### DIFF
--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/resources/css/slack-settings.less
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/resources/css/slack-settings.less
@@ -2,7 +2,7 @@
   padding: 1px 20px 20px;
 }
 
-.error-panel{
+#error-panel{
   display:none;
 }
 

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/resources/js/slack-feature/settings/slack-settings.js
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/resources/js/slack-feature/settings/slack-settings.js
@@ -58,7 +58,8 @@ AJS.toInit(function ($) {
      */
     function showError(error) {
         var errorPanel = $("#error-panel");
-        errorPanel.append(" Could not complete the action : Status [" + error.status + "] Reason [" + error.statusText + "]");
+        var reason = error.responseText || error.statusText
+        errorPanel.append(" Could not complete the action : Status [" + error.status + "] Reason [" + reason + "]");
         errorPanel.show();
     }
 });

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/resources/slack-soy/settings/settings.soy
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/resources/slack-soy/settings/settings.soy
@@ -79,7 +79,7 @@
  * Show general information about issue preview in global and project configuration
  */
 {template .preview}
-    <div class="aui-message aui-message-error error-panel"></div>
+    <div class="aui-message aui-message-error" id="error-panel"></div>
     <h5>{getText('jira.plugins.slack.admin.settings.autoconvert.preview')}</h5>
     <p>{getText('jira.plugins.slack.admin.settings.autoconvert.description')}</p>
     <img class="autoconvert-image-preview"/>


### PR DESCRIPTION
The PR contains 2 fixes:
1. Error messages weren't displayed correctly during saving of the advanced options because of minor issue in front-end code. See the attached screenshot for the current error message design. 
2. Jira/System Admin wasn't allowed to modify project-level advanced settings.

<img width="569" alt="AdvancedSettingsError" src="https://user-images.githubusercontent.com/66078253/161805931-fdbe07d2-7420-4b16-8d57-76c649c8f46c.png">