### PR TITLE
Issue #228: Added ignoring of rich_text block parsing error

### DIFF
--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/service/task/impl/SendNotificationTask.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/service/task/impl/SendNotificationTask.java
@@ -86,7 +86,7 @@ public class SendNotificationTask implements Callable<Void> {
 
                     retryLoaderHelper.retryWithUserTokens(
                             client,
-                            localClient -> localClient.postMessage(message.getMessageRequest()).toOptional(),
+                            localClient -> localClient.postMessage(message.getMessageRequest()),
                             RetryUser.botUser(),
                             RetryUser.userKey(message.getConfigurationOwner()));
                 }

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/test/java/com/atlassian/jira/plugins/slack/service/task/impl/SendNotificationTaskTest.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/test/java/com/atlassian/jira/plugins/slack/service/task/impl/SendNotificationTaskTest.java
@@ -10,6 +10,7 @@ import com.atlassian.plugins.slack.api.client.RetryLoaderHelper;
 import com.atlassian.plugins.slack.api.client.RetryUser;
 import com.atlassian.plugins.slack.api.client.SlackClient;
 import com.atlassian.plugins.slack.api.client.SlackClientProvider;
+import com.atlassian.plugins.slack.util.ErrorResponse;
 import com.github.seratch.jslack.api.methods.request.chat.ChatPostMessageRequest;
 import com.github.seratch.jslack.api.model.Message;
 import io.atlassian.fugue.Either;
@@ -64,7 +65,7 @@ public class SendNotificationTaskTest {
     private Message message;
 
     @Captor
-    private ArgumentCaptor<Function<SlackClient, Optional<Message>>> loaderCaptor;
+    private ArgumentCaptor<Function<SlackClient, Either<ErrorResponse, Message>>> loaderCaptor;
     @Captor
     private ArgumentCaptor<RetryUser> retryUserCaptor1;
     @Captor
@@ -109,7 +110,7 @@ public class SendNotificationTaskTest {
         verify(retryLoaderHelper).retryWithUserTokens(
                 same(client), loaderCaptor.capture(), retryUserCaptor1.capture(), retryUserCaptor2.capture());
 
-        assertThat(loaderCaptor.getValue().apply(client), is(Optional.of(message)));
+        assertThat(loaderCaptor.getValue().apply(client).toOptional(), is(Optional.of(message)));
 
         retryUserCaptor1.getValue().withClient(client);
         verify(client, never()).withInstallerUserToken();

--- a/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/api/client/RetryLoaderHelper.java
+++ b/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/api/client/RetryLoaderHelper.java
@@ -1,10 +1,12 @@
 package com.atlassian.plugins.slack.api.client;
 
+import com.atlassian.plugins.slack.util.ErrorResponse;
+import com.google.gson.JsonParseException;
+import io.atlassian.fugue.Either;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
 import java.util.function.Function;
-import java.util.stream.Stream;
 
 @Service
 public class RetryLoaderHelper {
@@ -18,11 +20,33 @@ public class RetryLoaderHelper {
      * @return Item loaded, if any
      */
     public <T> Optional<T> retryWithUserTokens(final SlackClient baseSlackClient,
-                                               final Function<SlackClient, Optional<T>> loader,
+                                               final Function<SlackClient, Either<ErrorResponse, T>> loader,
                                                final RetryUser... retryUsers) {
-        return Stream.of(retryUsers)
-                .map(retry -> retry.withClient(baseSlackClient))
-                .flatMap(clientOptional -> clientOptional.flatMap(loader).map(Stream::of).orElseGet(Stream::empty))
-                .findFirst();
+        for (RetryUser retryUser : retryUsers) {
+            Optional<SlackClient> authenticatedClient = retryUser.withClient(baseSlackClient);
+            Optional<Either<ErrorResponse, T>> response = authenticatedClient.map(loader);
+            if (response.isPresent()) {
+                Either<ErrorResponse, T> either = response.get();
+
+                // successful request; return result, skip other retry alternatives
+                if (either.isRight()) {
+                    return either.toOptional();
+                }
+
+                // an error happened
+                ErrorResponse errorResponse = either.left().get();
+                Throwable exception = errorResponse.getException();
+
+                // error parsing unsupported block ('rich_text' or other); ignore it and stop retrying
+                // TODO: remove this workaround when REST client is upgraded to stop failing on unknown blocks
+                if (exception instanceof JsonParseException &&
+                        exception.getMessage().contains("Unsupported layout block type")) {
+                    return Optional.empty();
+                }
+                // else some other error happened; keep retrying
+            }
+        }
+
+        return Optional.empty();
     }
 }

--- a/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/util/ErrorResponse.java
+++ b/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/util/ErrorResponse.java
@@ -81,7 +81,7 @@ public class ErrorResponse {
 
     @Override
     public String toString() {
-        return "ResourceError{" +
+        return "ErrorResponse{" +
                 "message=" + message +
                 ", statusCode=" + statusCode +
                 '}';


### PR DESCRIPTION
Slack `chat.postMessage` started responding with `rich_text` block that `jslack` doesn't support. It throws an exception that is considered being an authentication issue, that causes a retry with new credentials. The purpose of this PR is to prevent retries on API response parsing errors to prevent duplicate notifications being to Slack channels. It doesn't solve the issue with parsing. It will be fixed next as it requires more time.