### PR TITLE
Issue/228: Patch jslack to stop it throwing an exception on unknown blocks

### DIFF
--- a/.github/workflows/all-tests.yml
+++ b/.github/workflows/all-tests.yml
@@ -19,8 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     steps:
-      - run: echo 'Github event inputs [${{ toJson(github.event.inputs) }}].'
-      - run: echo 'Head commit message [${{ github.event.head_commit.message }}].'
+      - run: echo "Github event inputs [${{ toJson(github.event.inputs) }}]."
+      - run: echo "Head commit message [${{ github.event.head_commit.message }}]."
 
   unit-tests:
     name: Unit Tests

--- a/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/api/client/DefaultSlackClientProvider.java
+++ b/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/api/client/DefaultSlackClientProvider.java
@@ -7,6 +7,7 @@ import com.atlassian.plugins.slack.api.client.cache.SlackResponseCache;
 import com.atlassian.plugins.slack.api.client.interceptor.BackoffRetryInterceptor;
 import com.atlassian.plugins.slack.api.client.interceptor.RateLimitRetryInterceptor;
 import com.atlassian.plugins.slack.api.client.interceptor.RequestIdInterceptor;
+import com.atlassian.plugins.slack.api.client.jslack.PatchedSlackHttpClient;
 import com.atlassian.plugins.slack.link.SlackLinkManager;
 import com.atlassian.plugins.slack.user.SlackUserManager;
 import com.atlassian.sal.api.user.UserManager;
@@ -99,7 +100,7 @@ public class DefaultSlackClientProvider implements SlackClientProvider, Disposab
     @Override
     public SlackClient withLink(final SlackLink link) {
         checkNotNull(link, "link cannot be null");
-        return new DefaultSlackClient(new SlackHttpClient(
+        return new DefaultSlackClient(new PatchedSlackHttpClient(
                 client.get()), link, slackUserManager, userManager, eventPublisher, slackResponseCache);
     }
 
@@ -107,13 +108,13 @@ public class DefaultSlackClientProvider implements SlackClientProvider, Disposab
     public Either<Throwable, SlackClient> withTeamId(final String teamId) {
         return slackLinkManager
                 .getLinkByTeamId(teamId)
-                .map(link -> new DefaultSlackClient(new SlackHttpClient(
+                .map(link -> new DefaultSlackClient(new PatchedSlackHttpClient(
                         client.get()), link, slackUserManager, userManager, eventPublisher, slackResponseCache));
     }
 
     @Override
     public SlackLimitedClient withoutCredentials() {
-        return new DefaultSlackLimitedClient(Slack.getInstance(new SlackHttpClient(client.get())));
+        return new DefaultSlackLimitedClient(Slack.getInstance(new PatchedSlackHttpClient(client.get())));
     }
 
     @Override
@@ -195,7 +196,6 @@ public class DefaultSlackClientProvider implements SlackClientProvider, Disposab
             if (forceHttp1) {
                 builder.protocols(Collections.singletonList(Protocol.HTTP_1_1));
             }
-
 
             final OkHttpClient client = builder.build();
             if (log.isDebugEnabled()) {

--- a/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/api/client/RetryLoaderHelper.java
+++ b/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/api/client/RetryLoaderHelper.java
@@ -32,17 +32,6 @@ public class RetryLoaderHelper {
                 if (either.isRight()) {
                     return either.toOptional();
                 }
-
-                // an error happened
-                ErrorResponse errorResponse = either.left().get();
-                Throwable exception = errorResponse.getException();
-
-                // error parsing unsupported block ('rich_text' or other); ignore it and stop retrying
-                // TODO: remove this workaround when REST client is upgraded to stop failing on unknown blocks
-                if (exception instanceof JsonParseException &&
-                        exception.getMessage().contains("Unsupported layout block type")) {
-                    return Optional.empty();
-                }
                 // else some other error happened; keep retrying
             }
         }

--- a/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/api/client/jslack/PatchedGsonLayoutBlockFactory.java
+++ b/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/api/client/jslack/PatchedGsonLayoutBlockFactory.java
@@ -1,0 +1,50 @@
+package com.atlassian.plugins.slack.api.client.jslack;
+
+import com.github.seratch.jslack.api.model.block.ActionsBlock;
+import com.github.seratch.jslack.api.model.block.ContextBlock;
+import com.github.seratch.jslack.api.model.block.DividerBlock;
+import com.github.seratch.jslack.api.model.block.ImageBlock;
+import com.github.seratch.jslack.api.model.block.LayoutBlock;
+import com.github.seratch.jslack.api.model.block.SectionBlock;
+import com.github.seratch.jslack.common.json.GsonLayoutBlockFactory;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
+
+import java.lang.reflect.Type;
+
+/**
+ * Factory that handles unknown BlockKit blocks gracefully without throwing exceptions (as it does GsonLayoutBlockFactory).
+ */
+public class PatchedGsonLayoutBlockFactory extends GsonLayoutBlockFactory {
+    // copied from com.github.seratch.jslack.common.json.GsonLayoutBlockFactory.deserialize() without changes
+    @Override
+    public LayoutBlock deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+            throws JsonParseException {
+        final JsonObject jsonObject = json.getAsJsonObject();
+        final JsonPrimitive prim = (JsonPrimitive) jsonObject.get("type");
+        final String blockType = prim.getAsString();
+        final Class<? extends LayoutBlock> clazz = getLayoutClassInstance(blockType);
+        return context.deserialize(jsonObject, clazz);
+    }
+
+    // com.github.seratch.jslack.common.json.GsonLayoutBlockFactory.getLayoutClassInstance() with change of unknown blocks handling
+    private Class<? extends LayoutBlock> getLayoutClassInstance(String blockType) {
+        switch (blockType) {
+            case SectionBlock.TYPE:
+                return SectionBlock.class;
+            case DividerBlock.TYPE:
+                return DividerBlock.class;
+            case ImageBlock.TYPE:
+                return ImageBlock.class;
+            case ContextBlock.TYPE:
+                return ContextBlock.class;
+            case ActionsBlock.TYPE:
+                return ActionsBlock.class;
+            default:
+                return UnsupportedLayoutBlock.class; // fix
+        }
+    }
+}

--- a/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/api/client/jslack/PatchedSlackHttpClient.java
+++ b/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/api/client/jslack/PatchedSlackHttpClient.java
@@ -1,0 +1,60 @@
+package com.atlassian.plugins.slack.api.client.jslack;
+
+import com.github.seratch.jslack.SlackConfig;
+import com.github.seratch.jslack.api.methods.SlackApiException;
+import com.github.seratch.jslack.api.model.block.ContextBlockElement;
+import com.github.seratch.jslack.api.model.block.LayoutBlock;
+import com.github.seratch.jslack.api.model.block.composition.TextObject;
+import com.github.seratch.jslack.api.model.block.element.BlockElement;
+import com.github.seratch.jslack.common.http.SlackHttpClient;
+import com.github.seratch.jslack.common.json.GsonBlockElementFactory;
+import com.github.seratch.jslack.common.json.GsonContextBlockElementFactory;
+import com.github.seratch.jslack.common.json.GsonTextObjectFactory;
+import com.github.seratch.jslack.common.json.UnknownPropertyDetectionAdapterFactory;
+import com.google.gson.FieldNamingPolicy;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import okhttp3.OkHttpClient;
+import okhttp3.Response;
+
+import java.io.IOException;
+
+/**
+ * Main purpose of this class it to pass PatchedGsonLayoutBlockFactory instead of GsonLayoutBlockFactory provided by
+ * jslack 1.5.6 as the standard factory throws exceptions when an unknown BlockKit block is received from the Slack API.
+ */
+public class PatchedSlackHttpClient extends SlackHttpClient {
+    public PatchedSlackHttpClient(OkHttpClient okHttpClient) {
+        super(okHttpClient);
+    }
+
+    // copied from com.github.seratch.jslack.common.http.SlackHttpClient#parseJsonResponse(...) Gson replacement
+    @Override
+    public <T> T parseJsonResponse(Response response, Class<T> clazz) throws IOException, SlackApiException {
+        if (response.code() == 200) {
+            String body = response.body().string();
+            runHttpResponseListeners(response, body);
+            return createSnakeCase(getConfig()).fromJson(body, clazz); // fix
+        } else {
+            String body = response.body().string();
+            throw new SlackApiException(response, body);
+        }
+    }
+
+    // copied from com.github.seratch.jslack.common.json.GsonFactory#createSnakeCase(SlackConfig) with GsonLayoutBlockFactory modification
+    private Gson createSnakeCase(SlackConfig config) {
+        GsonBuilder gsonBuilder = new GsonBuilder()
+                .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
+                .registerTypeAdapter(LayoutBlock.class, new PatchedGsonLayoutBlockFactory()) // fix
+                .registerTypeAdapter(TextObject.class, new GsonTextObjectFactory())
+                .registerTypeAdapter(ContextBlockElement.class, new GsonContextBlockElementFactory())
+                .registerTypeAdapter(BlockElement.class, new GsonBlockElementFactory());
+        if (config.isLibraryMaintainerMode()) {
+            gsonBuilder = gsonBuilder.registerTypeAdapterFactory(new UnknownPropertyDetectionAdapterFactory());
+        }
+        if (config.isPrettyResponseLoggingEnabled()) {
+            gsonBuilder = gsonBuilder.setPrettyPrinting();
+        }
+        return gsonBuilder.create();
+    }
+}

--- a/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/api/client/jslack/UnsupportedLayoutBlock.java
+++ b/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/api/client/jslack/UnsupportedLayoutBlock.java
@@ -1,0 +1,17 @@
+package com.atlassian.plugins.slack.api.client.jslack;
+
+import com.github.seratch.jslack.api.model.block.LayoutBlock;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Some BlockKit blocks aren't supported by jslack 1.5.6. This class is a generic representation for those blocks.
+ * At the moment aren't interested in fields of that blocks, so the same class may be used for all the blocks.
+ */
+@Data
+@NoArgsConstructor
+public class UnsupportedLayoutBlock implements LayoutBlock {
+    public static final String TYPE = "unsupported_block";
+
+    private String type = TYPE;
+}


### PR DESCRIPTION
Hotfix for this issue was implemented in #229 . The problem with that implementation is that `jslack` throws an exception on every notification being sent to Slack. The plugin correctly handles that exception, but it is still suboptimal solution. In this PR `jslack` is patched to not throw an exception at all.

Also, a small fix was added to the build script to fix CI failures when a commit message contains a quote a double quote.