### PR TITLE
Issue #14 : Improve validation of Slack signature verification error

### DIFF
--- a/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/rest/SlackSignatureVerifyingFilter.java
+++ b/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/rest/SlackSignatureVerifyingFilter.java
@@ -159,6 +159,7 @@ public class SlackSignatureVerifyingFilter implements ContainerRequestFilter, Re
                             .toString();
                     String expectedSignature = "v0=" + encodeHmacSha256(signingSecret, payloadToHash);
                     if (!Objects.equals(expectedSignature, actualSignature)) {
+                        LOG.error("Request signature verification failed. Expected signature: {} and payload: {}", expectedSignature, payloadToHash);
                         failVerification(new SecurityException("Request signature verification failed."),
                                 teamId, Cause.BAD_SIGNATURE);
                     }
@@ -229,7 +230,7 @@ public class SlackSignatureVerifyingFilter implements ContainerRequestFilter, Re
     private void failVerification(final SecurityException exception,
                                   final String teamId,
                                   final Cause cause) throws SecurityException {
-
+        LOG.error("Verification failed for teamId: {}", teamId, exception);
         AnalyticsContext analyticsContext = analyticsContextProvider.byTeamId(teamId);
         eventPublisher.publish(new SigningSecretVerificationFailedEvent(analyticsContext, cause));
         throw exception;

--- a/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/rest/SlackSignatureVerifyingFilter.java
+++ b/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/rest/SlackSignatureVerifyingFilter.java
@@ -159,7 +159,7 @@ public class SlackSignatureVerifyingFilter implements ContainerRequestFilter, Re
                             .toString();
                     String expectedSignature = "v0=" + encodeHmacSha256(signingSecret, payloadToHash);
                     if (!Objects.equals(expectedSignature, actualSignature)) {
-                        LOG.error("Request signature verification failed. Expected signature: {} and payload: {}", expectedSignature, payloadToHash);
+                        LOG.error("Request signature verification failed. Expected signature: {} actual singnature: {} and payload: {}", expectedSignature, actualSignature, payloadToHash);
                         failVerification(new SecurityException("Request signature verification failed."),
                                 teamId, Cause.BAD_SIGNATURE);
                     }


### PR DESCRIPTION
- Added error logger in `failVerification` method for logging `teamId`
- Added error logger in `validateSignature` method for logging `payload` and `expectedSingature`