### PR TITLE
Issue 230: Jira 9.5 support

### DIFF
--- a/.github/workflows/all-tests.yml
+++ b/.github/workflows/all-tests.yml
@@ -65,8 +65,12 @@ jobs:
     needs: unit-tests
     strategy:
       matrix:
-        java-version: [8, 11]
-        jira-version: [8.9.0, 9.0.0-m0008]
+        java-version: [8, 11, 17]
+        jira-version: [8.15.0, 9.5.0]
+        # Java 17 support is added only since Jira 9.5: https://confluence.atlassian.com/jiracore/preparing-for-jira-9-5-1167834011.html
+        exclude:
+          - java-version: 17
+            jira-version: 8.15.0
       fail-fast: false
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/all-tests.yml
+++ b/.github/workflows/all-tests.yml
@@ -13,7 +13,7 @@ on:
         description: Jobs to run (comma-separated, defaults to all)
         required: false
 
-# override Maven from Plugin SDK as it is too old to run Confluence 8
+# override Maven from Plugin SDK as it is too old to run Confluence 8 and Jira 9.5
 env:
   ATLAS_MVN: /usr/share/apache-maven-3.8.6/bin/mvn
 

--- a/.github/workflows/jira-int-tests.yml
+++ b/.github/workflows/jira-int-tests.yml
@@ -16,6 +16,10 @@ on:
         description: Testkit version to run tests against
         required: false
 
+# override Maven from Plugin SDK as it is too old to run Jira 9.5
+env:
+  ATLAS_MVN: /usr/share/apache-maven-3.8.6/bin/mvn
+
 jobs:
   integration-tests-jira:
     name: Jira Integration Tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ on:
         description: Next development version (default to next snapshot micro version)
         required: false
 
-# override Maven from Plugin SDK as it is too old to run Confluence 8
+# override Maven from Plugin SDK as it is too old to run Confluence 8 and Jira 9.5
 env:
   ATLAS_MVN: /usr/share/apache-maven-3.8.6/bin/mvn
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ or by manually downloading plugin JAR files from Marketplace pages for [Jira](ht
 or [Bitbucket](https://marketplace.atlassian.com/apps/1220729/bitbucket-server-for-slack-official?hosting=server&tab=overview) plugins.
 Links to the official documentation are specified on Marketplace pages.
 
-Supported products (on 12 Nov, 2022). See [EOL policy](https://confluence.atlassian.com/support/atlassian-support-end-of-life-policy-201851003.html).
-* Jira: 8.9.0 (EOL 20 May, 2022) JDK 8, 11 - 9.0.0-m0008 (EOL TBD - start of 2024) on JDK 8, 11.
+Supported products (on 8th Dec, 2022). See [EOL policy](https://confluence.atlassian.com/support/atlassian-support-end-of-life-policy-201851003.html).
+* Jira: 8.15.0 (EOL date: 2 Feb 2023) JDK 8, 11 - 9.5.0 (EOL date: 6 Dec 2024) on JDK 8, 11, 17.
 * Confluence: 7.10 (EOL date: Dec 15, 2022) JDK 8, 11 - 8.0.0-m90 (EOL date: TBD - end of 2024) JDK 8, 11.
 * Bitbucket: 7.0.0 (EOL date: 5 March 2022) on JDK 8, 11 - 7.21.0 (EOL date: 2 March 2024) on JDK 8, 11.
 

--- a/README.md
+++ b/README.md
@@ -37,9 +37,11 @@ After successful installation running `atlas-version` should print SDK version.
 If you don't have ngrok, the plugin still can send notification to Slack in uni-directional way. 
 Slack demands HTTPS OAuth redirect URLs, so you also need to add your ngrok host to domain allowlist at
 http://localhost:2990/jira/plugins/servlet/whitelist. 
-4. If you are setting up the project for the first time run `./jira.sh common` from the project root directory to install 
+4. Install Maven 3.8.6 or later and define path to its executable: `export ATLAS_MVN: /usr/share/apache-maven-3.8.6/bin/mvn`.
+It's needed because current versions of AMPS plugin isn't compatible with Maven bundled into the Atlassian Plugin SDK.
+5. If you are setting up the project for the first time run `./jira.sh common` from the project root directory to install 
 all common modules to local Maven repository.
-5. Go to **\<product> Plugin Development** section for further steps. 
+6. Go to **\<product> Plugin Development** section for further steps. 
 
 # Jira Server Plugin Development
 

--- a/bitbucket-slack-server-integration-plugin/pom.xml
+++ b/bitbucket-slack-server-integration-plugin/pom.xml
@@ -258,7 +258,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.8</version>
+            <version>1.18.24</version>
             <scope>provided</scope>
         </dependency>
 

--- a/confluence-slack-integration/confluence-slack-server-integration-plugin/pom.xml
+++ b/confluence-slack-integration/confluence-slack-server-integration-plugin/pom.xml
@@ -281,6 +281,8 @@
                     <log4jProperties>src/main/resources/log4j.properties</log4jProperties>
                     <forceUpdateCheck>false</forceUpdateCheck>
 
+                    <!-- MaxPermSize is unsupported in Java 17 and JVM fails to start -->
+                    <!-- remove the option when Java 17 support is needed -->
                     <jvmArgs>-Xmx2g -XX:MaxPermSize=512m</jvmArgs>
                     <jvmDebugPort>5006</jvmDebugPort>
 

--- a/jira-slack-server-integration/jira-8-compat/pom.xml
+++ b/jira-slack-server-integration/jira-8-compat/pom.xml
@@ -20,6 +20,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.atlassian.sal</groupId>

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/pom.xml
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/pom.xml
@@ -638,6 +638,7 @@
                 <jdk>17</jdk>
             </activation>
             <properties>
+                <!-- Needed to start Jira on JDK 17 -->
                 <jvm17.opens>--add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.management/javax.management=ALL-UNNAMED --add-opens=java.desktop/sun.font=ALL-UNNAMED --add-opens=java.base/sun.reflect.generics.parser=ALL-UNNAMED --add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED --add-opens=java.base/java.time=ALL-UNNAMED --add-exports=java.base/sun.util.calendar=ALL-UNNAMED --add-exports=java.base/sun.security.action=ALL-UNNAMED --add-exports=java.xml/jdk.xml.internal=ALL-UNNAMED</jvm17.opens>
             </properties>
         </profile>

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/pom.xml
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/pom.xml
@@ -367,6 +367,9 @@
 
                     <!-- Custom logging config to show logs from plugin classes by default -->
                     <log4jProperties>src/main/resources/log4j.properties</log4jProperties>
+                    <log4j2Config>src/main/resources/log4j2.xml</log4j2Config>
+
+                    <!-- Give Java more heap to make Jira faster -->
                     <jvmArgs>-Xmx2g -XX:MaxPermSize=512m</jvmArgs>
 
                     <pluginArtifacts>
@@ -619,7 +622,7 @@
     </build>
 
     <properties>
-        <jira.amps.version>8.2.2</jira.amps.version>
+        <jira.amps.version>8.7.0</jira.amps.version>
         <project.root.directory>${project.basedir}/../..</project.root.directory>
         <maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ss.SSSZ</maven.build.timestamp.format>
         <build.timestamp>${maven.build.timestamp}</build.timestamp>

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/pom.xml
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/pom.xml
@@ -370,7 +370,7 @@
                     <log4j2Config>src/main/resources/log4j2.xml</log4j2Config>
 
                     <!-- Give Java more heap to make Jira faster -->
-                    <jvmArgs>-Xmx2g -XX:MaxPermSize=512m</jvmArgs>
+                    <jvmArgs>-Xmx2g</jvmArgs>
 
                     <pluginArtifacts>
                         <pluginArtifact>

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/pom.xml
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/pom.xml
@@ -370,7 +370,7 @@
                     <log4j2Config>src/main/resources/log4j2.xml</log4j2Config>
 
                     <!-- Give Java more heap to make Jira faster -->
-                    <jvmArgs>-Xmx2g</jvmArgs>
+                    <jvmArgs>${jvm17.opens} -Xmx2g</jvmArgs>
 
                     <pluginArtifacts>
                         <pluginArtifact>
@@ -568,6 +568,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.22.1</version>
                 <configuration>
+                    <argLine>${jvm17.opens}</argLine>
                     <skipTests>${ut.test.skip}</skipTests>
                     <excludes>
                         <exclude>${functional.test.pattern}</exclude>
@@ -601,6 +602,7 @@
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <version>2.22.0</version>
                 <configuration>
+                    <argLine>${jvm17.opens}</argLine>
                     <trimStackTrace>false</trimStackTrace>
                 </configuration>
             </plugin>
@@ -626,9 +628,19 @@
         <project.root.directory>${project.basedir}/../..</project.root.directory>
         <maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ss.SSSZ</maven.build.timestamp.format>
         <build.timestamp>${maven.build.timestamp}</build.timestamp>
+        <jvm17.opens />
     </properties>
 
     <profiles>
+        <profile>
+            <id>jvm17</id>
+            <activation>
+                <jdk>17</jdk>
+            </activation>
+            <properties>
+                <jvm17.opens>--add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.management/javax.management=ALL-UNNAMED --add-opens=java.desktop/sun.font=ALL-UNNAMED --add-opens=java.base/sun.reflect.generics.parser=ALL-UNNAMED --add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED --add-opens=java.base/java.time=ALL-UNNAMED --add-exports=java.base/sun.util.calendar=ALL-UNNAMED --add-exports=java.base/sun.security.action=ALL-UNNAMED --add-exports=java.xml/jdk.xml.internal=ALL-UNNAMED</jvm17.opens>
+            </properties>
+        </profile>
         <profile>
             <id>jacoco</id>
             <build>

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/resources/log4j2.xml
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/resources/log4j2.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- modified standard logging config. See full config at <jira-home>/WEB-INF/classes/log4j2.xml -->
+<Configuration packages="com.atlassian.logging.log4j,com.atlassian.jira.logging">
+    <Properties>
+        <!-- date level [logger] message\n -->
+        <Property name="MyLogMessagePattern">%d %p [%c] %m%n</Property>
+    </Properties>
+
+    <Appenders>
+        <Console name="my-console">
+            <PatternLayout>
+                <Pattern>${MyLogMessagePattern}</Pattern>
+            </PatternLayout>
+        </Console>
+        <JiraHomeAppender name="my-filelog"
+                          fileName="atlassian-jira.log"
+                          filePattern="atlassian-jira.log.%i">
+            <PatternLayout>
+                <Pattern>${MyLogMessagePattern}</Pattern>
+            </PatternLayout>
+            <Policies>
+                <SizeBasedTriggeringPolicy size="20480 KB"/>
+            </Policies>
+            <DefaultRolloverStrategy fileIndex="min" max="10"/>
+        </JiraHomeAppender>
+    </Appenders>
+
+    <Loggers>
+        <Root level="WARN">
+            <AppenderRef ref="my-console"/>
+            <AppenderRef ref="my-filelog"/>
+        </Root>
+        <!-- logs from classes in common module -->
+        <Logger name="com.atlassian.plugins.slack" level="TRACE" additivity="false">
+            <AppenderRef ref="my-console"/>
+            <AppenderRef ref="my-filelog"/>
+        </Logger>
+        <!-- logs from classes in jira-specific module -->
+        <Logger name="com.atlassian.jira.plugins.slack" level="TRACE" additivity="false">
+            <AppenderRef ref="my-console"/>
+            <AppenderRef ref="my-filelog"/>
+        </Logger>
+        <!-- logs from integration tests -->
+        <Logger name="com.atlassian.jira.plugins.slack" level="TRACE" additivity="false">
+            <AppenderRef ref="my-console"/>
+            <AppenderRef ref="my-filelog"/>
+        </Logger>
+        <!-- jslack logs -->
+        <Logger name="com.github.seratach.jslack.maintainer.json" level="TRACE" additivity="false">
+            <AppenderRef ref="my-console"/>
+            <AppenderRef ref="my-filelog"/>
+        </Logger>
+        <!-- Spring start-up errors -->
+        <Logger name="org.springframework.beans.factory.support" level="ERROR" additivity="false">
+            <AppenderRef ref="my-console"/>
+            <AppenderRef ref="my-filelog"/>
+        </Logger>
+    </Loggers>
+</Configuration>

--- a/jira.sh
+++ b/jira.sh
@@ -24,11 +24,6 @@ Examples:
   ./jira.sh clean run    -> cleans all compiled files but the Jira home directory, compiles everything, and runs Jira in development mode
 "
 
-# check java 8
-javaVersion=`java -version 2>&1 | head -n 1 | cut -d\" -f 2`
-javaCompilerVersion=`javac -version 2>&1 | head -n 1 | cut -d\" -f 2`
-# [[ "$javaVersion" != "1.8."* || "$javaCompilerVersion" != *"1.8."* ]] && echo "Java 8 expected" && exit 1
-
 # compute parameters
 purge=$([[ "$*" == *"purge"* ]] && echo "yes" || echo "no")
 clean=$([[ "$*" == *"clean"* ]] && ([[ "$purge" == "yes" ]] && echo "skip" || echo "yes") || echo "no")

--- a/jira.sh
+++ b/jira.sh
@@ -27,7 +27,7 @@ Examples:
 # check java 8
 javaVersion=`java -version 2>&1 | head -n 1 | cut -d\" -f 2`
 javaCompilerVersion=`javac -version 2>&1 | head -n 1 | cut -d\" -f 2`
-[[ "$javaVersion" != "1.8."* || "$javaCompilerVersion" != *"1.8."* ]] && echo "Java 8 expected" && exit 1
+# [[ "$javaVersion" != "1.8."* || "$javaCompilerVersion" != *"1.8."* ]] && echo "Java 8 expected" && exit 1
 
 # compute parameters
 purge=$([[ "$*" == *"purge"* ]] && echo "yes" || echo "no")

--- a/pom.xml
+++ b/pom.xml
@@ -395,7 +395,7 @@
             <dependency>
                 <groupId>org.projectlombok</groupId>
                 <artifactId>lombok</artifactId>
-                <version>1.18.8</version>
+                <version>1.18.24</version>
             </dependency>
             <dependency>
                 <groupId>commons-codec</groupId>


### PR DESCRIPTION
- I added Jira 9.5.0 to the supported Jira versions and set Jira 8.15.0 as the oldest supported version since it reached its [End of Life date](https://confluence.atlassian.com/support/atlassian-support-end-of-life-policy-201851003.html).
- Java 17 is now supported by Jira 9.5.0. To implement it:
  - AMPS version was bumped.
  - Lombok version was bumped to the latest one.
  - Maven 3.8.6 is now used in Jira integration tests workflow.
  - `opens` and `exports` instructions were added to the JVM command arguments. It is needed because of enforcement of Java module policies in Java 17
  -  `-XX:MaxPermSize` command line options was removed because it is remove in Java 17 and now blocks JVM start up.
- Log4j config was replicated in Log4j2 XML format