### PR TITLE
Issue 242: Added installation of the supported git version before running Bitbucket integration tests

### DIFF
--- a/.github/workflows/all-tests.yml
+++ b/.github/workflows/all-tests.yml
@@ -142,18 +142,23 @@ jobs:
   integration-tests-bitbucket:
     name: Bitbucket
     runs-on: ubuntu-20.04
-    timeout-minutes: 15
+    timeout-minutes: 20
     if: github.event.inputs.jobs == '' || contains(github.event.inputs.jobs, 'integration-tests-bitbucket')
     needs: unit-tests
     strategy:
       matrix:
         java-version: [8, 11]
-        bitbucket-version: [7.0.0, 8.0.0-breakit-m13]
+        bitbucket-version: [7.6.0, 8.6.1]
       fail-fast: false
     steps:
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.ref }}
+      # Dec 13, 2022
+      # latest Bitbucket 8.6.1 doesn't support latest git 2.38.1 installed on the Ubuntu 20 image Github provides
+      # install last supported git - 2.37.4; remove this trick once Bitbucket implements support for latest git
+      # https://confluence.atlassian.com/bitbucketserver/supported-platforms-776640981.html#Supportedplatforms-dvcsDVCS
+      - run: bin/build/install-supported-git.sh
       - uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.java-version }}

--- a/.github/workflows/bitbucket-int-tests.yml
+++ b/.github/workflows/bitbucket-int-tests.yml
@@ -17,12 +17,17 @@ jobs:
   integration-tests-bitbucket:
     name: Bitbucket Integration Tests
     runs-on: ubuntu-20.04
-    timeout-minutes: 15
+    timeout-minutes: 20
     steps:
       - run: echo 'Github event inputs [${{ toJson(github.event.inputs) }}].'
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.ref }}
+      # Dec 13, 2022
+      # latest Bitbucket 8.6.1 doesn't support latest git 2.38.1 installed on the Ubuntu 20 image Github provides
+      # install last supported git - 2.37.4; remove this trick once Bitbucket implements support for latest git
+      # https://confluence.atlassian.com/bitbucketserver/supported-platforms-776640981.html#Supportedplatforms-dvcsDVCS
+      - run: bin/build/install-supported-git.sh
       - uses: actions/setup-java@v3
         with:
           java-version: ${{ github.event.inputs.java-version }}

--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ or by manually downloading plugin JAR files from Marketplace pages for [Jira](ht
 or [Bitbucket](https://marketplace.atlassian.com/apps/1220729/bitbucket-server-for-slack-official?hosting=server&tab=overview) plugins.
 Links to the official documentation are specified on Marketplace pages.
 
-Supported products (on 8th Dec, 2022). See [EOL policy](https://confluence.atlassian.com/support/atlassian-support-end-of-life-policy-201851003.html).
+Supported products (on 13th Dec, 2022). See [EOL policy](https://confluence.atlassian.com/support/atlassian-support-end-of-life-policy-201851003.html).
 * Jira: 8.15.0 (EOL date: 2 Feb 2023) JDK 8, 11 - 9.5.0 (EOL date: 6 Dec 2024) on JDK 8, 11, 17.
 * Confluence: 7.10 (EOL date: Dec 15, 2022) JDK 8, 11 - 8.0.0-m90 (EOL date: TBD - end of 2024) JDK 8, 11.
-* Bitbucket: 7.0.0 (EOL date: 5 March 2022) on JDK 8, 11 - 7.21.0 (EOL date: 2 March 2024) on JDK 8, 11.
+* Bitbucket: 7.6.0 (EOL date: Q1 calendar year 2023) on JDK 8, 11 - 8.6.1 (EOL date: 15 Nov 2024) on JDK 8, 11.
 
 ## A note on future development plans
 

--- a/bin/build/install-supported-git.sh
+++ b/bin/build/install-supported-git.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -ex
+trap 'set +ex' EXIT
+
+git --version
+
+dpkg -l | grep git
+sudo apt remove git git-man
+dpkg -l | grep git
+
+# Instruction: https://www.digitalocean.com/community/tutorials/how-to-install-git-from-source-on-ubuntu-20-04-quickstart
+sudo apt update
+sudo apt install libz-dev libssl-dev libcurl4-gnutls-dev libexpat1-dev gettext cmake gcc
+mkdir git-src
+cd git-src
+curl -o git.tar.gz https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.37.4.tar.gz
+tar -zxf git.tar.gz
+cd git-*
+make prefix=/usr/local all
+sudo make prefix=/usr/local install
+
+echo $PATH
+/usr/local/bin/git --version

--- a/bitbucket-slack-server-integration-plugin/pom.xml
+++ b/bitbucket-slack-server-integration-plugin/pom.xml
@@ -46,8 +46,8 @@
 
         <!-- product properties -->
         <plugin.key>${project.groupId}.${project.artifactId}</plugin.key>
-        <bitbucket.api.version>7.0.0</bitbucket.api.version>
-        <bitbucket.version>7.0.0</bitbucket.version>
+        <bitbucket.api.version>7.6.0</bitbucket.api.version>
+        <bitbucket.version>7.6.0</bitbucket.version>
         <bitbucket.data.version>${bitbucket.version}</bitbucket.data.version>
         <bitbucket.amps.version>8.2.2</bitbucket.amps.version>
         <platform.version>5.0.0</platform.version>


### PR DESCRIPTION
Bitbucket integration tests started failing some time ago. It was caused by the change in image used by Github Actions for tests - recently release git 2.38.1 was installed. The problem was that Bitbucket doesn't yet support this git version and just fails to start.
So, I had to downgrade git to latest supported version 2.37.4 before running Bitbucket integration tests. These is no easy way to do that because Ubuntu repository doesn't store all package versions and doesn't even contain the latest version. The only version currently present there is 2.25.1, that is [too old for BItbucket to support](https://confluence.atlassian.com/bitbucketserver/supported-platforms-776640981.html#Supportedplatforms-dvcsDVCS) =( So, the only option left was to build git of the needed version from scratch. Luckily, this approach is already properly documented here: https://www.digitalocean.com/community/tutorials/how-to-install-git-from-source-on-ubuntu-20-04-quickstart