### PR TITLE
Issue 245: Fixed integration tests for Confluence 8

### DIFF
--- a/.github/workflows/all-tests.yml
+++ b/.github/workflows/all-tests.yml
@@ -107,11 +107,13 @@ jobs:
     strategy:
       matrix:
         # every version part should be 0 <= <version> <= 255; otherwise Confluence fails to start
-        java-version: [8, 11]
-        confluence-version: [7.10.0, 8.0.0-m90]
+        java-version: [8, 11, 17]
+        confluence-version: [7.10.0, 8.0.0]
         exclude:
           - java-version: 8
-            confluence-version: 8.0.0-m90 # Confluence 8 doesn't support Java 8 anymore
+            confluence-version: 8.0.0 # Confluence 8 doesn't support Java 8 anymore
+          - java-version: 17
+            confluence-version: 7.10.0
       fail-fast: false
     steps:
       - uses: actions/checkout@v3

--- a/bitbucket-slack-server-integration-plugin/pom.xml
+++ b/bitbucket-slack-server-integration-plugin/pom.xml
@@ -522,7 +522,7 @@
                     <plugin>
                         <groupId>org.jacoco</groupId>
                         <artifactId>jacoco-maven-plugin</artifactId>
-                        <version>0.8.2</version>
+                        <version>0.8.8</version>
                         <configuration>
                             <includes>
                                 <include>com/atlassian/bitbucket/plugins/slack/**</include>

--- a/confluence-slack-integration/confluence-slack-server-integration-plugin/pom.xml
+++ b/confluence-slack-integration/confluence-slack-server-integration-plugin/pom.xml
@@ -29,6 +29,7 @@
         <confluence.data.version>${confluence.version}</confluence.data.version>
 
         <confluence.amps.version>8.6.0</confluence.amps.version>
+        <jvm17.opens />
     </properties>
 
     <dependencies>
@@ -283,7 +284,7 @@
 
                     <!-- MaxPermSize is unsupported in Java 17 and JVM fails to start -->
                     <!-- remove the option when Java 17 support is needed -->
-                    <jvmArgs>-Xmx2g -XX:MaxPermSize=512m</jvmArgs>
+                    <jvmArgs>${jvm17.opens} -Xmx2g</jvmArgs>
                     <jvmDebugPort>5006</jvmDebugPort>
 
                     <systemPropertyVariables combine.children="append">
@@ -417,10 +418,20 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.22.1</version>
                 <configuration>
+                    <argLine>${jvm17.opens}</argLine>
                     <skipTests>${ut.test.skip}</skipTests>
                     <excludes>
                         <exclude>${functional.test.pattern}</exclude>
                     </excludes>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <argLine>${jvm17.opens}</argLine>
+                    <trimStackTrace>false</trimStackTrace>
                 </configuration>
             </plugin>
 
@@ -502,6 +513,16 @@
     </build>
 
     <profiles>
+        <profile>
+            <id>jvm17</id>
+            <activation>
+                <jdk>17</jdk>
+            </activation>
+            <properties>
+                <!-- Needed to start Confluence 8 on JDK 17 -->
+                <jvm17.opens>--add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED --add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED --add-opens=java.base/sun.net.www.protocol.http=ALL-UNNAMED --add-opens=java.base/sun.net.www.protocol.https=ALL-UNNAMED --add-opens=java.base/sun.util.locale=ALL-UNNAMED --add-opens=java.management/javax.management=ALL-UNNAMED --add-exports=java.base/sun.security.action=ALL-UNNAMED --add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED --add-exports=java.xml/com.sun.org.apache.xml.internal.utils=ALL-UNNAMED --add-exports=java.desktop/sun.font=ALL-UNNAMED --add-exports=java.base/sun.security.util=ALL-UNNAMED</jvm17.opens>
+            </properties>
+        </profile>
         <profile>
             <id>jacoco</id>
             <build>

--- a/pom.xml
+++ b/pom.xml
@@ -531,7 +531,7 @@
                     <plugin>
                         <groupId>org.jacoco</groupId>
                         <artifactId>jacoco-maven-plugin</artifactId>
-                        <version>0.8.2</version>
+                        <version>0.8.8</version>
                         <executions>
                             <execution>
                                 <goals>


### PR DESCRIPTION
- Confluence 8 doesn't support Java 8 anymore, but supports Java 17. These changes were added to test workflow files.
- Also, to run Confluence 8 on Java 11 additional Java options need to be passed on startup. 
- `-XX:MaxPermSize` support was dropped on Java 17, so it needed to be removed from params list.