### PR TITLE
Updates for vulnerable libraries

### DIFF
--- a/bitbucket-slack-server-integration-plugin/pom.xml
+++ b/bitbucket-slack-server-integration-plugin/pom.xml
@@ -35,7 +35,6 @@
 
         <!-- dependency versions -->
         <atlassian.spring.scanner.version>2.1.7</atlassian.spring.scanner.version>
-        <jslack.version>1.5.6</jslack.version>
         <junit.jupiter.version>5.7.1</junit.jupiter.version>
         <mockito-core.version>2.25.0</mockito-core.version>
         <atlassian.selenium.version>3.0.0</atlassian.selenium.version>
@@ -69,10 +68,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <!-- Override vulnerable okhttp 3.14.1 used by jslack -->
             <dependency>
                 <groupId>com.squareup.okhttp3</groupId>
                 <artifactId>okhttp</artifactId>
-                <version>3.14.9</version>
+                <version>4.10.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -89,7 +89,13 @@
             <groupId>com.github.seratch</groupId>
             <artifactId>jslack</artifactId>
             <scope>compile</scope>
-            <version>${jslack.version}</version>
+            <version>1.5.6</version>
+        </dependency>
+        <!-- Override vulnerable gson 2.8.5 used by jslack -->
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.8.9</version>
         </dependency>
         <dependency>
             <groupId>com.atlassian.ozymandias</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -45,8 +45,6 @@
         <project.scm.id>github</project.scm.id>
 
         <!-- Dependencies -->
-        <jslack.version>1.5.6</jslack.version>
-        <gson.version>2.8.9</gson.version>
         <atlassian.spring.scanner.version>2.1.7</atlassian.spring.scanner.version>
         <analytics-api.version>3.15</analytics-api.version>
         <slf4j.version>1.7.25</slf4j.version>
@@ -63,6 +61,7 @@
         <atlassian-annotations.version>2.1.0</atlassian-annotations.version>
         <atlassian-event.version>4.0.0</atlassian-event.version>
         <ao.version>1.3.0</ao.version>
+        <okhttp.version>4.10.0</okhttp.version>
 
         <servlet.version>3.0.1</servlet.version>
         <spring-test.version>5.3.18</spring-test.version>
@@ -126,7 +125,7 @@
             <dependency>
                 <groupId>com.github.seratch</groupId>
                 <artifactId>jslack</artifactId>
-                <version>${jslack.version}</version>
+                <version>1.5.6</version>
                 <exclusions>
                     <exclusion>
                         <artifactId>slf4j-api</artifactId>
@@ -134,10 +133,11 @@
                     </exclusion>
                 </exclusions>
             </dependency>
+            <!-- Override vulnerable gson 2.8.5 used by jslack -->
             <dependency>
                 <groupId>com.google.code.gson</groupId>
                 <artifactId>gson</artifactId>
-                <version>${gson.version}</version>
+                <version>2.8.9</version>
             </dependency>
 
             <dependency>
@@ -478,15 +478,16 @@
                 <scope>test</scope>
             </dependency>
 
+            <!-- Override vulnerable okhttp 3.14.1 used by jslack -->
             <dependency>
                 <groupId>com.squareup.okhttp3</groupId>
                 <artifactId>okhttp</artifactId>
-                <version>3.14.9</version>
+                <version>${okhttp.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.squareup.okhttp3</groupId>
                 <artifactId>mockwebserver</artifactId>
-                <version>3.14.9</version>
+                <version>${okhttp.version}</version>
                 <scope>test</scope>
             </dependency>
 


### PR DESCRIPTION
OkHttp and Gson used in the plugins have known vulnerabilities. I upgraded both libraries to newer non-vulnerable versions.