### PR TITLE
Issue #259: Bitbucket 8.8 support

### DIFF
--- a/.github/workflows/all-tests.yml
+++ b/.github/workflows/all-tests.yml
@@ -148,8 +148,12 @@ jobs:
     needs: unit-tests
     strategy:
       matrix:
-        java-version: [8, 11]
-        bitbucket-version: [7.6.0, 8.6.1]
+        java-version: [8, 11, 17]
+        bitbucket-version: [7.6.0, 8.8.0]
+        # Bitbucket 8.8.0 is the first one that supports Java 17
+        exclude:
+          - java-version: 17
+            bitbucket-version: 7.6.0
       fail-fast: false
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ or by manually downloading plugin JAR files from Marketplace pages for [Jira](ht
 or [Bitbucket](https://marketplace.atlassian.com/apps/1220729/bitbucket-server-for-slack-official?hosting=server&tab=overview) plugins.
 Links to the official documentation are specified on Marketplace pages.
 
-Supported products (on 13th Dec, 2022). See [EOL policy](https://confluence.atlassian.com/support/atlassian-support-end-of-life-policy-201851003.html).
+Supported products (on 10th Feb, 2023). See [EOL policy](https://confluence.atlassian.com/support/atlassian-support-end-of-life-policy-201851003.html).
 * Jira: 8.15.0 (EOL date: 2 Feb 2023) JDK 8, 11 - 9.5.0 (EOL date: 6 Dec 2024) on JDK 8, 11, 17.
 * Confluence: 7.10 (EOL date: Dec 15, 2022) JDK 8, 11 - 8.0.0-m90 (EOL date: TBD - end of 2024) JDK 8, 11.
 * Bitbucket: 7.6.0 (EOL date: Q1 calendar year 2023) on JDK 8, 11 - 8.8.0 (EOL date: 7 Feb 2025) on JDK 8, 11, 17.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Links to the official documentation are specified on Marketplace pages.
 Supported products (on 13th Dec, 2022). See [EOL policy](https://confluence.atlassian.com/support/atlassian-support-end-of-life-policy-201851003.html).
 * Jira: 8.15.0 (EOL date: 2 Feb 2023) JDK 8, 11 - 9.5.0 (EOL date: 6 Dec 2024) on JDK 8, 11, 17.
 * Confluence: 7.10 (EOL date: Dec 15, 2022) JDK 8, 11 - 8.0.0-m90 (EOL date: TBD - end of 2024) JDK 8, 11.
-* Bitbucket: 7.6.0 (EOL date: Q1 calendar year 2023) on JDK 8, 11 - 8.6.1 (EOL date: 15 Nov 2024) on JDK 8, 11.
+* Bitbucket: 7.6.0 (EOL date: Q1 calendar year 2023) on JDK 8, 11 - 8.8.0 (EOL date: 7 Feb 2025) on JDK 8, 11, 17.
 
 ## A note on future development plans
 

--- a/bitbucket-slack-server-integration-plugin/pom.xml
+++ b/bitbucket-slack-server-integration-plugin/pom.xml
@@ -421,7 +421,7 @@
                     <skipAllPrompts>true</skipAllPrompts>
 
                     <!-- It allows to connect to Bitbucket embedded database while it is running -->
-                    <jvmArgs>${jvm17.opens} -Djdbc.url=jdbc:h2:${project.build.directory}/bitbucket/home/shared/data/db;DB_CLOSE_DELAY=-1</jvmArgs>
+                    <jvmArgs>${jvm17.opens} -Djdbc.url=jdbc:h2:${project.build.directory}/bitbucket/home/shared/data/db;DB_CLOSE_DELAY=-1;AUTO_SERVER=TRUE</jvmArgs>
                     <jvmDebugPort>5007</jvmDebugPort>
 
                     <systemPropertyVariables>

--- a/bitbucket-slack-server-integration-plugin/pom.xml
+++ b/bitbucket-slack-server-integration-plugin/pom.xml
@@ -420,7 +420,7 @@
                     <skipAllPrompts>true</skipAllPrompts>
 
                     <!-- It allows to connect to Bitbucket embedded database while it is running -->
-                    <jvmArgs>-Djdbc.url=jdbc:h2:${project.build.directory}/bitbucket/home/shared/data/db;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;AUTO_SERVER=TRUE</jvmArgs>
+                    <jvmArgs>-Djdbc.url=jdbc:h2:${project.build.directory}/bitbucket/home/shared/data/db;DB_CLOSE_DELAY=-1</jvmArgs>
                     <jvmDebugPort>5007</jvmDebugPort>
 
                     <systemPropertyVariables>

--- a/bitbucket-slack-server-integration-plugin/pom.xml
+++ b/bitbucket-slack-server-integration-plugin/pom.xml
@@ -20,6 +20,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <jvm17.opens />
 
         <!-- default properties. copied from parent POM in order to allow to resolve plugin plugin dependencies during BBS build -->
         <it.test.skip>true</it.test.skip>
@@ -420,7 +421,7 @@
                     <skipAllPrompts>true</skipAllPrompts>
 
                     <!-- It allows to connect to Bitbucket embedded database while it is running -->
-                    <jvmArgs>-Djdbc.url=jdbc:h2:${project.build.directory}/bitbucket/home/shared/data/db;DB_CLOSE_DELAY=-1</jvmArgs>
+                    <jvmArgs>${jvm17.opens} -Djdbc.url=jdbc:h2:${project.build.directory}/bitbucket/home/shared/data/db;DB_CLOSE_DELAY=-1</jvmArgs>
                     <jvmDebugPort>5007</jvmDebugPort>
 
                     <systemPropertyVariables>
@@ -489,10 +490,21 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.22.1</version>
                 <configuration>
+                    <argLine>${jvm17.opens}</argLine>
                     <skipTests>${ut.test.skip}</skipTests>
                     <excludes>
                         <exclude>${functional.test.pattern}</exclude>
                     </excludes>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>2.22.0</version>
+                <configuration>
+                    <argLine>${jvm17.opens}</argLine>
+                    <trimStackTrace>false</trimStackTrace>
                 </configuration>
             </plugin>
 
@@ -521,6 +533,16 @@
     </build>
 
     <profiles>
+        <profile>
+            <id>jvm17</id>
+            <activation>
+                <jdk>17</jdk>
+            </activation>
+            <properties>
+                <!-- Needed to start Bitbucket on JDK 17 -->
+                <jvm17.opens>--add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED</jvm17.opens>
+            </properties>
+        </profile>
         <profile>
             <id>jacoco</id>
             <build>


### PR DESCRIPTION
* Integration tests were failing because of disallowed combination of JDBC parameters. It was legal on H2 used in Bitbucket 8.7, but became disallowed in H2 used in Bitbucket 8.8.
* Also JDK 17 is now supported. In order to run Bitbucket on it, additional opens/exports need to be added to command line arguments like it was already done for Jira and Confluence plugins.
* Since we need to support Bitbucket 8.8 I also added it to the `all-tests.yml`.