### PR TITLE
Issue #274: Rolled back Backbone to 1.0.0

### DIFF
--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/resources/atlassian-plugin.xml
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/resources/atlassian-plugin.xml
@@ -125,7 +125,7 @@
     </web-resource>
 
     <web-resource key="slack-backbone-resource">
-        <dependency>jira.webresources:backbone-1.3.3</dependency>
+        <dependency>jira.webresources:backbone-1.0.0</dependency>
         <resource type="download" name="slack-backbone-amd.js" location="js/lib/backbone-amd.js"/>
     </web-resource>
 

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/resources/js/lib/backbone-amd.js
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/resources/js/lib/backbone-amd.js
@@ -1,5 +1,5 @@
 define('slack/backbone', [
-    'jira/backbone-1.3.3'
+    'backbone'
 ], function (Backbone) {
     return Backbone;
 });


### PR DESCRIPTION
Dedicated channel deletion  client-side logic relies on Backbone 1.0.0 API and upgrade to 1.3.3 broke it. Rolling it back to make dedicated channel deletion working again.