### PR TITLE
Added a requirement to use dev as base branch for contributions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,18 +1,25 @@
 # Contributing to Atlassian Slack Integration for Server
 
-Thank you for considering a contribution to Atlassian Slack Integration for Server project! Pull requests, issues and comments are welcome. For pull requests, please:
+Thank you for considering a contribution to Atlassian Slack Integration for Server project! Pull requests, issues and 
+comments are welcome. For pull requests, please:
 
+* Use `dev` as base branch for your changes and target branch for your PRs 
 * Add tests for new features and bug fixes
 * Follow the existing style
 * Separate unrelated changes into multiple pull requests
 
 See the existing issues for things to start contributing.
 
-For bigger changes, please make sure you start a discussion first by creating an issue and explaining the intended change.
+For bigger changes, please make sure you start a discussion first by creating an issue and explaining the intended 
+change.
 
-Atlassian requires contributors to sign a Contributor License Agreement, known as a CLA. This serves as a record stating that the contributor is entitled to contribute the code/documentation/translation to the project and is willing to have it used in distributions and derivative works (or is willing to transfer ownership).
+Atlassian requires contributors to sign a Contributor License Agreement, known as a CLA. This serves as a record stating
+that the contributor is entitled to contribute the code/documentation/translation to the project and is willing to have 
+it used in distributions and derivative works (or is willing to transfer ownership).
 
-Prior to accepting your contributions we ask that you please follow the appropriate link below to digitally sign the CLA. The Corporate CLA is for those who are contributing as a member of an organization and the individual CLA is for those contributing as an individual.
+Prior to accepting your contributions we ask that you please follow the appropriate link below to digitally sign the 
+CLA. The Corporate CLA is for those who are contributing as a member of an organization and the individual CLA is for 
+those contributing as an individual.
 
 * [CLA for corporate contributors](https://opensource.atlassian.com/corporate)
 * [CLA for individuals](https://opensource.atlassian.com/individual)


### PR DESCRIPTION
This point was missed in the original version of the recommendations, that cause an additional corrections step on every external contribution.