### PR TITLE
Made DbConsole working again

### DIFF
--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/pom.xml
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/pom.xml
@@ -624,7 +624,7 @@
     </build>
 
     <properties>
-        <jira.amps.version>8.7.0</jira.amps.version>
+        <jira.amps.version>8.10.4</jira.amps.version>
         <project.root.directory>${project.basedir}/../..</project.root.directory>
         <maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ss.SSSZ</maven.build.timestamp.format>
         <build.timestamp>${maven.build.timestamp}</build.timestamp>

--- a/jira-slack-server-integration/pom.xml
+++ b/jira-slack-server-integration/pom.xml
@@ -22,12 +22,12 @@
         <aui.version>5.1.3</aui.version>
 
         <!-- this is the version we will run integration tests against -->
-        <jira.version>9.0.0-m0008</jira.version>
+        <jira.version>9.0.0</jira.version>
         <testkit.version>8.1.51</testkit.version>
         <jira.test.unit.version>${jira.version}</jira.test.unit.version>
 
         <!-- This is the version the plugin is compiled against -->
-        <jira.compile.version>9.0.0-m0008</jira.compile.version>
+        <jira.compile.version>9.0.0</jira.compile.version>
 
         <jira.pageobjects.version>${jira.version}</jira.pageobjects.version>
 


### PR DESCRIPTION
DbConsole got broken some time ago. Upgrading AMPS seems to fix it.
This change affects only local development.