### PR TITLE
Change "Server" with "Data Center" in text labels in the plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 
-# Atlassian Server Integrations for Slack
+# Atlassian Data Center Integrations for Slack
 
 [![Atlassian license](https://img.shields.io/badge/license-Apache%202.0-blue.svg?style=flat-square)](LICENSE) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](CONTRIBUTING.md)
 
-Official plugins for Jira Server, Confluence Server, and Bitbucket Server that integrate with [Slack](https://slack.com/).
+Official plugins for Jira Data Center, Confluence Data Center, and Bitbucket Date Center that integrate with [Slack](https://slack.com/).
 
 
 # Usage
 
 Jira, Confluence or Bitbucket administrator can install Slack plugin to their system via embedded Marketplace (**\<Configuration gear\>** -> **Find new apps/plugins**)
-or by manually downloading plugin JAR files from Marketplace pages for [Jira](https://marketplace.atlassian.com/apps/1220099/jira-server-for-slack-official?hosting=server&tab=overview), 
+or by manually downloading plugin JAR files from Marketplace pages for [Jira](https://marketplace.atlassian.com/apps/1220099/jira-server-for-slack-official?hosting=datacenter&tab=overview), 
 [Confluence](https://marketplace.atlassian.com/apps/1220186/confluence-server-for-slack-official?hosting=datacenter&tab=overview) 
-or [Bitbucket](https://marketplace.atlassian.com/apps/1220729/bitbucket-server-for-slack-official?hosting=server&tab=overview) plugins.
+or [Bitbucket](https://marketplace.atlassian.com/apps/1220729/bitbucket-server-for-slack-official?hosting=datacenter&tab=overview) plugins.
 Links to the official documentation are specified on Marketplace pages.
 
 Supported products (on 10th Feb, 2023). See [EOL policy](https://confluence.atlassian.com/support/atlassian-support-end-of-life-policy-201851003.html).
@@ -23,7 +23,7 @@ Supported products (on 10th Feb, 2023). See [EOL policy](https://confluence.atla
 
 In order to [accelerate our journey to the cloud, together](https://www.atlassian.com/blog/announcements/journey-to-cloud), Atlassian will continue to maintain these apps' _compatibility_ with our Server products. However, we will not be creating new features or matching feature parity with our Cloud integrations. If you would like to add your own customizations/features to the integration, we encourage you to fork this repository and customize it as you wish like we’ve seen many customers do.
 
-When Jira, Confluence, or Bitbucket Server release new versions, we will validate the compatibility of these apps and release new versions within four weeks of their public release.
+When Jira, Confluence, or Bitbucket Data Center release new versions, we will validate the compatibility of these apps and release new versions within four weeks of their public release.
 
 # Installation
 
@@ -43,7 +43,7 @@ It's needed because current versions of AMPS plugin isn't compatible with Maven 
 all common modules to local Maven repository.
 6. Go to **\<product> Plugin Development** section for further steps. 
 
-# Jira Server Plugin Development
+# Jira Plugin Development
 
 Use tool `./jira.sh` for all dev cycle:
 
@@ -67,11 +67,11 @@ Use tool `./jira.sh` for all dev cycle:
 ./jira.sh purge
 ```
 
-# Confluence Server Plugin Development
+# Confluence Plugin Development
 
 Use tool `./confluence.sh` for all dev cycle. It has a similar set of commands to `./jira.sh` (see **Jira Server Plugin Development** section).
 
-# Bitbucket Server Plugin Development
+# Bitbucket Plugin Development
 
 Use tool `./bitbucket.sh` for all dev cycle. It has a similar set of commands to `./jira.sh` (see **Jira Server Plugin Development** section).
 
@@ -140,7 +140,7 @@ This action should be usually be run by repo maintainer only. See workflow confi
 
 # Contributions
 
-Contributions to Atlassian Server Integrations for Slack project are welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for details.
+Contributions to Atlassian Data Center Integrations for Slack project are welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for details.
 
 # License
 

--- a/bitbucket-slack-server-integration-plugin/pom.xml
+++ b/bitbucket-slack-server-integration-plugin/pom.xml
@@ -7,8 +7,8 @@
     <packaging>atlassian-plugin</packaging>
     <version>4.0.7-SNAPSHOT</version>
 
-    <name>Slack for Bitbucket Server</name>
-    <description>This is the Slack integration for Bitbucket Server</description>
+    <name>Slack for Bitbucket Data Center</name>
+    <description>This is the Slack integration for Bitbucket Data Center</description>
 
     <organization>
         <name>Atlassian</name>

--- a/bitbucket-slack-server-integration-plugin/src/main/resources/com/atlassian/bitbucket/plugins/slack/bitbucket-slack.properties
+++ b/bitbucket-slack-server-integration-plugin/src/main/resources/com/atlassian/bitbucket/plugins/slack/bitbucket-slack.properties
@@ -4,15 +4,15 @@ slack.blueprint.app.id=AK9SSVATB
 # Admin
 plugins.slack.admin.title=Slack integration
 plugins.slack.admin.connect.content=Give your Bitbucket projects a voice in Slack.
-plugins.slack.admin.connect.workspace.install.in.slack = Set up the Bitbucket Server app on Slack
-plugins.slack.admin.connect.workspace.edit.in.slack = Set up the Bitbucket Server app on Slack
-plugins.slack.admin.connect.workspace.description=With Bitbucket Server and Slack integrated, your team will always be \
-  up to date. When an important event happens in Bitbucket Server they''ll be notified in Slack. \
+plugins.slack.admin.connect.workspace.install.in.slack = Set up the Bitbucket Data Center app on Slack
+plugins.slack.admin.connect.workspace.edit.in.slack = Set up the Bitbucket Data Center app on Slack
+plugins.slack.admin.connect.workspace.description=With Bitbucket Data Center and Slack integrated, your team will always be \
+  up to date. When an important event happens in Bitbucket Data Center they''ll be notified in Slack. \
   They may even be able to take action in Slack, depending on the notification. To get started, follow the instructions below.
 plugins.slack.admin.connect.workspace.basic.button.description=1. Click <strong>Go to Slack</strong> and follow the \
   <a href="https://confluence.atlassian.com/slack/use-slack-and-bitbucket-server-together-974387205.html#UseSlackandBitbucketServertogether-HowdoIconfigureandconnecttheBitbucketServerforSlackapptomyBitbucketsite?" target="_blank">instructions to set up the app</a>.<br> \
   2. When asked to <strong>Add your Slack credentials to your app</strong>, click <strong>Copy</strong>.<br> \
-  3. Click <strong>Submit</strong> then come back to Bitbucket Server.<br>
+  3. Click <strong>Submit</strong> then come back to Bitbucket Data Center.<br>
 plugins.slack.admin.connect.workspace.advanced.button.description=1. Click <strong>Go to Slack</strong> and \
   <a href="https://confluence.atlassian.com/slack/use-slack-and-bitbucket-server-together-974387205.html#UseSlackandBitbucketServertogether-IusemultipleBitbucketServerinstancesormyinstancesarebehindafirewall.HowdoIconnectthemtoSlack?" target="_blank">create an app</a>.<br>\
   2. In Slack, go to <strong>OAuth & Permissions > Scopes</strong> and select a permission scope for the app.<br>\
@@ -31,7 +31,7 @@ plugins.slack.admin.connection.status.partial.connectivity.tooltip.description =
   You can still receive messages in Slack, but some new functionality<br> (such as slash command and comment replies) may not work.
 
 bitbucket.plugins.slack.admin.title=Slack integration
-bitbucket.plugins.slack.admin.description=Help your team stay up to date with everything happening in Bitbucket Server
+bitbucket.plugins.slack.admin.description=Help your team stay up to date with everything happening in Bitbucket Data Center
 slack.admin.savedsuccessfully=Slack configuration saved successfully!
 slack.admin.admintoken=Admin Token
 slack.admin.apibaseurl=API Base URL
@@ -159,7 +159,7 @@ bitbucket.plugins.slack.remove-dialog.content.html=Are you sure you want to stop
 bitbucket.plugins.slack.remove-dialog.title=Stop notifying this channel
 
 bitbucket.plugins.slack.slack.team.list.title=Your Slack workspaces
-bitbucket.plugins.slack.channelmapping.repository.header=Bitbucket Server Repository
+bitbucket.plugins.slack.channelmapping.repository.header=Bitbucket Data Center Repository
 bitbucket-ui-components.repository-picker.placeholder=Select a repository
 bitbucket.plugins.slack.admin.repository.picker.empty=Type to start searching
 bitbucket-ui-components.repository-picker.search-results=Search results
@@ -191,12 +191,12 @@ slack2-repository-configuration.remove.dialog.confirm=Stop notifications
 slack2-repository-configuration.remove.dialog.cancel=Cancel
 
 # service notifications
-slack.notification.channel-linked={0} has set up Bitbucket Server notifications for this channel. Notifications for events from the repository, *{1}*, will now appear here.
+slack.notification.channel-linked={0} has set up Bitbucket Data Center notifications for this channel. Notifications for events from the repository, *{1}*, will now appear here.
 slack.notification.workspace.connected.welcome=This workspace is now connected to <{0}> :tada:\n\
-  The next step is to confirm your account in Bitbucket Server. Then you can choose events to see notifications for, \
+  The next step is to confirm your account in Bitbucket Data Center. Then you can choose events to see notifications for, \
   and the channels where these notifications will appear. You''ll also be able to take action on some notifications \
-  and unfurl relevant Bitbucket Server links when they''re pasted in Slack. \
-  If you''re an admin of this Bitbucket Server instance, you can configure this integration in the <{1}|administration page>. \
+  and unfurl relevant Bitbucket Data Center links when they''re pasted in Slack. \
+  If you''re an admin of this Bitbucket Data Center instance, you can configure this integration in the <{1}|administration page>. \
   For more help, take a look at our <https://confluence.atlassian.com/slack/use-slack-and-bitbucket-server-together-974387205.html|documentation>.
 
 # user triggered notifications
@@ -281,7 +281,7 @@ slack.user.link.confirm.account.message=:bulb: In order to see a preview of your
   please <{0}|confirm your account in Bitbucket>.
 
 # personal notifications
-plugins.slack.pn.page.info=To help you keep up to date you can choose to receive direct messages in Slack when important events happen in Bitbucket Server.
+plugins.slack.pn.page.info=To help you keep up to date you can choose to receive direct messages in Slack when important events happen in Bitbucket Data Center.
 plugins.slack.pn.field.pr_author=A pull request that I''m the author of is updated
 plugins.slack.pn.field.pr_watcher=A pull request that I''m watching is updated
 plugins.slack.pn.field.pr_reviewer_created=I''m added as a reviewer to a pull request

--- a/bitbucket-slack-server-integration-plugin/src/test/java/it/com/atlassian/bitbucket/plugins/slack/functional/WorkspaceLinkFuncTest.java
+++ b/bitbucket-slack-server-integration-plugin/src/test/java/it/com/atlassian/bitbucket/plugins/slack/functional/WorkspaceLinkFuncTest.java
@@ -52,10 +52,10 @@ public class WorkspaceLinkFuncTest extends SlackFunctionalTestBase {
                 ChatPostMessageRequest.builder()
                         .channel(DIRECT.getId())
                         .text("This workspace is now connected to <http://example.com/context/dashboard?atlLinkOrigin=c2xhY2staW50ZWdyYXRpb258c2l0ZQ%3D%3D|" + applicationTitle + "> :tada:\n"
-                                + "The next step is to confirm your account in Bitbucket Server. Then you can choose events to see notifications for, "
+                                + "The next step is to confirm your account in Bitbucket Data Center. Then you can choose events to see notifications for, "
                                 + "and the channels where these notifications will appear. You'll also be able to take action on some notifications "
-                                + "and unfurl relevant Bitbucket Server links when they're pasted in Slack. "
-                                + "If you're an admin of this Bitbucket Server instance, you can configure this integration in the <http://example.com/context/plugins/servlet/slack/configure?teamId=DUMMY-T123456|administration page>. "
+                                + "and unfurl relevant Bitbucket Data Center links when they're pasted in Slack. "
+                                + "If you're an admin of this Bitbucket Data Center instance, you can configure this integration in the <http://example.com/context/plugins/servlet/slack/configure?teamId=DUMMY-T123456|administration page>. "
                                 + "For more help, take a look at our <https://confluence.atlassian.com/slack/use-slack-and-bitbucket-server-together-974387205.html|documentation>.")
                         .build()
         )))));

--- a/bitbucket-slack-server-integration-plugin/src/test/java/it/com/atlassian/bitbucket/plugins/slack/web/ConfigurationWebTest.java
+++ b/bitbucket-slack-server-integration-plugin/src/test/java/it/com/atlassian/bitbucket/plugins/slack/web/ConfigurationWebTest.java
@@ -68,7 +68,7 @@ public class ConfigurationWebTest extends SlackWebTestBase {
 
         assertThat(server.requestHistoryForTest(), hasHit(CHAT_POST_MESSAGE, contains(
                 requestEntityProperty(ChatPostMessageRequest::getText, containsString(
-                        "has set up Bitbucket Server notifications for this channel. Notifications for events from the repository, *<http://example.com/context/projects/PROJECT_1/repos/rep_1/browse?atlLinkOrigin=c2xhY2staW50ZWdyYXRpb258cmVwb3NpdG9yeQ%3D%3D|Project 1/rep_1>*, will now appear here."))
+                        "has set up Bitbucket Data Center notifications for this channel. Notifications for events from the repository, *<http://example.com/context/projects/PROJECT_1/repos/rep_1/browse?atlLinkOrigin=c2xhY2staW50ZWdyYXRpb258cmVwb3NpdG9yeQ%3D%3D|Project 1/rep_1>*, will now appear here."))
         )));
 
         assertThat(server.requestHistoryForTest(), hasHit(CONVERSATIONS_INVITE, contains(allOf(

--- a/confluence-slack-integration/confluence-7-compat/pom.xml
+++ b/confluence-slack-integration/confluence-7-compat/pom.xml
@@ -11,7 +11,7 @@
 
     <artifactId>confluence-7-compat</artifactId>
     <packaging>jar</packaging>
-    <name>Confluence Server 7 Compatibility Package</name>
+    <name>Confluence Data Center 7 Compatibility Package</name>
 
     <dependencies>
         <dependency>

--- a/confluence-slack-integration/confluence-8-compat/pom.xml
+++ b/confluence-slack-integration/confluence-8-compat/pom.xml
@@ -11,7 +11,7 @@
 
     <artifactId>confluence-8-compat</artifactId>
     <packaging>jar</packaging>
-    <name>Confluence Server 8 Compatibility Package</name>
+    <name>Confluence Data Center 8 Compatibility Package</name>
 
     <dependencies>
         <dependency>

--- a/confluence-slack-integration/confluence-compat-common/pom.xml
+++ b/confluence-slack-integration/confluence-compat-common/pom.xml
@@ -11,7 +11,7 @@
 
     <artifactId>confluence-compat-common</artifactId>
     <packaging>jar</packaging>
-    <name>Confluence Server Compatibility Common Package</name>
+    <name>Confluence Data Center Compatibility Common Package</name>
 
     <dependencies>
         <dependency>

--- a/confluence-slack-integration/confluence-slack-server-integration-plugin/pom.xml
+++ b/confluence-slack-integration/confluence-slack-server-integration-plugin/pom.xml
@@ -10,9 +10,9 @@
     <groupId>com.atlassian.confluence.plugins</groupId>
     <artifactId>confluence-slack-server-integration-plugin</artifactId>
     <packaging>atlassian-plugin</packaging>
-    <name>Slack for Confluence Server</name>
+    <name>Slack for Confluence Data Center</name>
     <version>3.0.3-SNAPSHOT</version>
-    <description>This is the Slack integration for Confluence Server</description>
+    <description>This is the Slack integration for Confluence Data Center</description>
 
     <properties>
         <plugin.key>${project.groupId}.${project.artifactId}</plugin.key>

--- a/confluence-slack-integration/confluence-slack-server-integration-plugin/src/main/resources/com/atlassian/confluence/plugins/slack/confluence-slack.properties
+++ b/confluence-slack-integration/confluence-slack-server-integration-plugin/src/main/resources/com/atlassian/confluence/plugins/slack/confluence-slack.properties
@@ -4,7 +4,7 @@ plugins.slack.admin.label=Slack integration
 plugins.slack.admin.connect.content=Give your Confluence spaces a voice in Slack.
 plugins.slack.admin.choose.title=Set up Slack notifications
 plugins.slack.admin.title=Slack integration
-plugins.slack.admin.description=Help your team stay up to date with everything happening in Confluence Server
+plugins.slack.admin.description=Help your team stay up to date with everything happening in Confluence Data Center
 plugins.slack.admin.choose.content=Choose the events you want to be notified about.
 plugins.slack.admin.choose.complete.content=<strong>Awesome!</strong> Go ahead and set up more channels below.
 
@@ -134,15 +134,15 @@ slack.blueprint.app.id=AG28M10D8
 
 slack.oauth2.error.link.not.found=Confluence is not connected with workspace {0}
 plugins.slack.admin.connection.status.oauth.failure.tooltip.description = The integration may have been removed from Slack.<br> Please update your credentials in Confluence.
-plugins.slack.admin.connect.workspace.install.in.slack = Set up the Confluence Server App on Slack
-plugins.slack.admin.connect.workspace.edit.in.slack = Set up the Confluence Server App on Slack
-plugins.slack.admin.connect.workspace.description=With Confluence Server and Slack integrated, your team will always be \
-  up to date. When an important event happens in Confluence Server they''ll be notified in Slack. \
+plugins.slack.admin.connect.workspace.install.in.slack = Set up the Confluence Data Center App on Slack
+plugins.slack.admin.connect.workspace.edit.in.slack = Set up the Confluence Data Center App on Slack
+plugins.slack.admin.connect.workspace.description=With Confluence Data Center and Slack integrated, your team will always be \
+  up to date. When an important event happens in Confluence Data Center they''ll be notified in Slack. \
   To get started, follow the instructions below.
 plugins.slack.admin.connect.workspace.basic.button.description=1. Click <strong>Go to Slack</strong> and follow the \
   <a href="https://confluence.atlassian.com/slack/use-slack-and-confluence-together-966662503.html#UseSlackandConfluencetogether-HowdoIconnecttheConfluenceServerforSlackapptomyConfluencesite?" target="_blank">instructions to set up the app</a>.<br> \
   2. When asked to <strong>Add your Slack credentials to your app</strong>, click <strong>Copy</strong>.<br> \
-  3. Click <strong>Submit</strong> then come back to Confluence Server.<br>
+  3. Click <strong>Submit</strong> then come back to Confluence Data Center.<br>
 plugins.slack.admin.connect.workspace.advanced.button.description=Click <strong>Go to Slack</strong> and \
   <a href="https://confluence.atlassian.com/slack/use-slack-and-confluence-together-966662503.html#UseSlackandConfluencetogether-IusemultipleConfluenceServerinstancesormyinstancesarebehindafirewall.HowdoIconnectthemtoSlack?" target="_blank">follow the steps to create an app</a>.<br>
 

--- a/jira-slack-server-integration/jira-8-compat/README.md
+++ b/jira-slack-server-integration/jira-8-compat/README.md
@@ -1,4 +1,4 @@
-# Atlassian Server Integrations for Slack
+# Atlassian Data Center Integrations for Slack
 
 This package contains Jira 8 specific implementations that would not compile in the main plugin.
 

--- a/jira-slack-server-integration/jira-8-compat/pom.xml
+++ b/jira-slack-server-integration/jira-8-compat/pom.xml
@@ -8,8 +8,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>jira-8-compat</artifactId>
-    <name>Jira Server 8 Compatibility Package</name>
-    <description>Provides compatibility with Java 8.</description>
+    <name>Jira Data Center 8 Compatibility Package</name>
+    <description>Provides compatibility with Jira 8.</description>
 
     <dependencies>
         <dependency>

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/pom.xml
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/pom.xml
@@ -12,8 +12,8 @@
     <packaging>atlassian-plugin</packaging>
     <version>3.0.8-SNAPSHOT</version>
 
-    <name>Slack for Jira Server</name>
-    <description>This is the Slack plugin for Jira Server</description>
+    <name>Slack for Jira Data Center</name>
+    <description>This is the Slack plugin for Jira Data Center</description>
 
     <dependencies>
         <!-- Embedded dependencies -->

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/resources/com/atlassian/jira/plugins/slack/jira-slack.properties
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/resources/com/atlassian/jira/plugins/slack/jira-slack.properties
@@ -1,6 +1,6 @@
 jira.plugins.slack.project.admin.link=Slack integration
 plugins.slack.admin.title=Slack integration
-plugins.slack.admin.description=Help your team stay up to date with everything happening in Jira Server
+plugins.slack.admin.description=Help your team stay up to date with everything happening in Jira Data Center
 jira.plugins.slack.integration.title=Slack integration
 jira.plugins.slack.integration.applications.title=Slack
 
@@ -308,7 +308,7 @@ jira.plugins.slack.mentions.dialog.login.message=<a href="#open-issue-mentions" 
 jira.plugins.slack.mentions.dialog.actions.login=Confirm
 
 # Connection status
-plugins.slack.admin.connection.status.partial.connectivity.tooltip.description = Slack cannot connect to your Jira server - it may be behind a firewall.<br> \
+plugins.slack.admin.connection.status.partial.connectivity.tooltip.description = Slack cannot connect to your Jira Data Center - it may be behind a firewall.<br> \
   You can still receive messages from Jira in Slack, but some functionality<br> (such as slash command or Issue Preview) may not work.
 plugins.slack.admin.connection.status.connection.error = Failed to contact Slack API
 plugins.slack.admin.connection.status.invalid.link.error = Slack link was not found
@@ -353,21 +353,21 @@ jira.plugins.slack.migration.success.message=The configuration of Hipchat room <
   migrated to the Slack channel <strong>{1}</strong>!
 
 jira.slack.unauthenticated.unfurl.message=:bulb: Looks like you''ve just shared the Jira issue <{0}>. \
-  In order to enable issue preview, <{1}|connect your Jira Server account> to your Slack account.
+  In order to enable issue preview, <{1}|connect your Jira Data Center account> to your Slack account.
 
 slack.blueprint.app.id=ADZHDM3L1
 
 slack.oauth2.error.link.not.found=Jira is not connected with workspace {0}
 plugins.slack.admin.connection.status.oauth.failure.tooltip.description = The integration may have been removed from Slack.<br> Please update your credentials in Jira.
-plugins.slack.admin.connect.workspace.install.in.slack = Set up the Jira Server App on Slack
-plugins.slack.admin.connect.workspace.edit.in.slack = Set up the Jira Server App on Slack
-plugins.slack.admin.connect.workspace.description=With Jira Server and Slack integrated, your team will always be \
-  up to date. When an important event happens in Jira Server they''ll be notified in Slack. \
+plugins.slack.admin.connect.workspace.install.in.slack = Set up the Jira Data Center App on Slack
+plugins.slack.admin.connect.workspace.edit.in.slack = Set up the Jira Data Center App on Slack
+plugins.slack.admin.connect.workspace.description=With Jira Data Center and Slack integrated, your team will always be \
+  up to date. When an important event happens in Jira Data Center they''ll be notified in Slack. \
   To get started, follow the instructions below.
 plugins.slack.admin.connect.workspace.basic.button.description=1. Click <strong>Go to Slack</strong> and follow the \
   <a href="https://confluence.atlassian.com/slack/using-jira-applications-with-slack-966662163.html#UsingJiraapplicationswithSlack-HowdoIconnecttheJiraServerforSlackapptomyJirasite?" target="_blank">instructions to set up the app</a>.<br> \
   2. When asked to <strong>Add your Slack credentials to your app</strong>, click <strong>Copy</strong>.<br> \
-  3. Click <strong>Submit</strong> then come back to Jira Server.<br>
+  3. Click <strong>Submit</strong> then come back to Jira Data Center.<br>
 plugins.slack.admin.connect.workspace.advanced.button.description=Click <strong>Go to Slack</strong> and \
   <a href="https://confluence.atlassian.com/slack/using-jira-applications-with-slack-966662163.html#UsingJiraapplicationswithSlack-IusemultipleJiraServerinstancesormyinstancesarebehindafirewall.HowdoIconnectthemtoSlack?" target="_blank">follow the steps to create an app</a>.<br>
 

--- a/slack-server-integration-common/pom.xml
+++ b/slack-server-integration-common/pom.xml
@@ -8,7 +8,7 @@
     </parent>
 
     <artifactId>slack-server-integration-common</artifactId>
-    <name>Atlassian Slack Server Integration Common</name>
+    <name>Atlassian Slack Data Center Integration Common</name>
     <description>Provides resources and functionality for linking Atlassian products with slack.</description>
 
     <dependencies>

--- a/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/api/webhooks/action/BlockSlackAction.java
+++ b/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/api/webhooks/action/BlockSlackAction.java
@@ -37,7 +37,7 @@ import java.util.List;
     "subtype": "bot_message",
     "text": "This content can't be displayed.",
     "ts": "1558648770.002300",
-    "username": "Bitbucket Server Michael Dev",
+    "username": "Bitbucket Data Center Dev",
     "bot_id": "BHXBB7QQ5",
     "blocks": [
       {


### PR DESCRIPTION
As the company changes its focus on supporting Data Center edition of products, the plugins get renamed as well. They are already renamed on Marketplace, this PR changes product mentions in various plugins messages.