### PR TITLE
#344 Ignore RESCOPED event without any changes to target PR

### DIFF
--- a/bitbucket-slack-server-integration-plugin/src/main/java/com/atlassian/bitbucket/plugins/slack/listener/BitbucketNotificationEventListener.java
+++ b/bitbucket-slack-server-integration-plugin/src/main/java/com/atlassian/bitbucket/plugins/slack/listener/BitbucketNotificationEventListener.java
@@ -6,6 +6,7 @@ import com.atlassian.bitbucket.event.content.FileEditedEvent;
 import com.atlassian.bitbucket.event.pull.PullRequestCommentEvent;
 import com.atlassian.bitbucket.event.pull.PullRequestEvent;
 import com.atlassian.bitbucket.event.pull.PullRequestOpenedEvent;
+import com.atlassian.bitbucket.event.pull.PullRequestRescopedEvent;
 import com.atlassian.bitbucket.event.pull.PullRequestReviewersUpdatedEvent;
 import com.atlassian.bitbucket.event.repository.RepositoryForkedEvent;
 import com.atlassian.bitbucket.event.repository.RepositoryRefsChangedEvent;
@@ -75,6 +76,14 @@ public class BitbucketNotificationEventListener {
             PullRequestCommentEvent commentEvent = (PullRequestCommentEvent) event;
             if (commentEvent.getComment().getSeverity() == BLOCKER) { //BLOCKER severity represents a PR task
                 onEvent(commentEvent);
+                return;
+            }
+        }
+        if (event instanceof PullRequestRescopedEvent) {
+            PullRequestRescopedEvent rescopedEvent = (PullRequestRescopedEvent) event;
+            // no changes for target PR
+            if (!Optional.ofNullable(rescopedEvent.getAddedCommits()).filter(commits -> commits.getTotal() > 0).isPresent() &&
+                !Optional.ofNullable(rescopedEvent.getRemovedCommits()).filter(commits -> commits.getTotal() > 0).isPresent()) {
                 return;
             }
         }

--- a/bitbucket-slack-server-integration-plugin/src/test/java/com/atlassian/bitbucket/plugins/slack/listener/BitbucketNotificationEventListenerTest.java
+++ b/bitbucket-slack-server-integration-plugin/src/test/java/com/atlassian/bitbucket/plugins/slack/listener/BitbucketNotificationEventListenerTest.java
@@ -45,6 +45,7 @@ import com.atlassian.bitbucket.plugins.slack.notification.TaskNotificationTypes;
 import com.atlassian.bitbucket.plugins.slack.notification.renderer.SlackNotificationRenderer;
 import com.atlassian.bitbucket.pull.PullRequest;
 import com.atlassian.bitbucket.pull.PullRequestRef;
+import com.atlassian.bitbucket.pull.SimpleRescopeDetails;
 import com.atlassian.bitbucket.repository.MinimalRef;
 import com.atlassian.bitbucket.repository.RefChange;
 import com.atlassian.bitbucket.repository.RefChangeType;
@@ -74,6 +75,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -271,7 +273,24 @@ class BitbucketNotificationEventListenerTest {
     }
 
     @Test
+    void onEvent_pullRequestRescopedEvent_shouldIgnoreNullChanges() {
+        target.onEvent(pullRequestRescopedEvent);
+
+        verifyNoMoreInteractions(notificationPublisher, slackNotificationRenderer);
+    }
+
+    @Test
+    void onEvent_pullRequestRescopedEvent_shouldIgnoreZeroChanges() {
+        when(pullRequestRescopedEvent.getAddedCommits()).thenReturn(SimpleRescopeDetails.EMPTY);
+        when(pullRequestRescopedEvent.getRemovedCommits()).thenReturn(SimpleRescopeDetails.EMPTY);
+        target.onEvent(pullRequestRescopedEvent);
+
+        verifyNoMoreInteractions(notificationPublisher, slackNotificationRenderer);
+    }
+
+    @Test
     void onEvent_pullRequestRescopedEvent_shouldCallExpectedMethods() {
+        when(pullRequestRescopedEvent.getAddedCommits()).thenReturn(new SimpleRescopeDetails.Builder().total(1).build());
         testPullRequestEvent(pullRequestRescopedEvent, PullRequestNotificationTypes.RESCOPED);
     }
 


### PR DESCRIPTION
Should reduce noise introduced in #277 and solve part of #344