### PR TITLE
Replace Jira testing license by compatible with Data Center

### DIFF
--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/test/java/it/com/atlassian/jira/plugins/slack/functional/SanityCheckFuncTest.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/test/java/it/com/atlassian/jira/plugins/slack/functional/SanityCheckFuncTest.java
@@ -14,20 +14,9 @@ import static org.hamcrest.Matchers.containsString;
 @SkipCacheCheck
 public class SanityCheckFuncTest extends SlackFunctionalTestBase {
 
-    public static final String LICENCE_FOR_TESTING = "AAAB8w0ODAoPeNp9Uk2P2jAQvedXWOoNydmELVKLFKlL4u7SLglKQj+27cEkA3gb7GjssMu/rwnQl\n" +
-            "s9DDvHMvPfmvXmTN0BGfE08n3jdftfv927J/SgnXc9/58wRQC5UXQO6j6IAqYGVwgglAxbnLB2nw\n" +
-            "4w5cbOcAiaziQbUge85oZKGFybmSwjKmiMKvfjATcW1Fly6hVo64waLBdcQcQPBhot6Per5zo4lX\n" +
-            "9fQjofJaMTScHj3uC+x11rgup0b3z7sudiIi+oSWQa4AhxGweD+fU6/Tb68pZ+fnh7owPO/Os8Cu\n" +
-            "VujKpvCuJsfqtXMvHAE1+KKFQQGG3A+2cp412XJeQjSHLVkzVQXKOrWn/bljH/nNmslXPa30+nES\n" +
-            "U4/Jikdp0k0CfNhEtNJxmwhCBGsFSWZrolZANmhECYLVQISu9gzFIb8WBhT/+zf3MyVe2DOTbWdo\n" +
-            "LCd+OWSSBGpDCmFNiimjQGLLDQxihSNNmppU3Yd67c0ILksjhOxqsKU3eUsooPvG4kXUrli/MlF7\n" +
-            "dayEU7kb6lepJOxOLAf7XneFmkfCuCp95nh+LdwhfegL8E5l0LzNo4IVlApi0Vy0GZvs9O6b+vHZ\n" +
-            "xzBv0toB3Yuk5lCwuualHs8fSD0/3NqdZ48nBd+5bjYilfNdokZr6zmP7TmY5YwLAIUNq8MbmR8G\n" +
-            "faV9ulfLz1K+3g9j1YCFDeq7aYROMQbwMIvHimNt7/bJCCIX02nj";
-
     @Before
     public void beforeEach() {
-        backdoor.restoreDataFromResource(SAMPLE_DATA, LICENCE_FOR_TESTING);
+        backdoor.restoreDataFromResource(SAMPLE_DATA);
     }
 
     @Test

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/test/java/it/com/atlassian/jira/plugins/slack/functional/SanityCheckFuncTest.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/test/java/it/com/atlassian/jira/plugins/slack/functional/SanityCheckFuncTest.java
@@ -6,7 +6,6 @@ import okhttp3.Response;
 import org.junit.Before;
 import org.junit.Test;
 
-import static com.atlassian.jira.testkit.client.util.TimeBombLicence.LICENCE_FOR_TESTING;
 import static com.atlassian.plugins.slack.test.RequestMatchers.success;
 import static it.com.atlassian.jira.plugins.slack.util.JiraFuncTestData.SAMPLE_DATA;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -14,6 +13,18 @@ import static org.hamcrest.Matchers.containsString;
 
 @SkipCacheCheck
 public class SanityCheckFuncTest extends SlackFunctionalTestBase {
+
+    public static final String LICENCE_FOR_TESTING = "AAAB8w0ODAoPeNp9Uk2P2jAQvedXWOoNydmELVKLFKlL4u7SLglKQj+27cEkA3gb7GjssMu/rwnQl\n" +
+            "s9DDvHMvPfmvXmTN0BGfE08n3jdftfv927J/SgnXc9/58wRQC5UXQO6j6IAqYGVwgglAxbnLB2nw\n" +
+            "4w5cbOcAiaziQbUge85oZKGFybmSwjKmiMKvfjATcW1Fly6hVo64waLBdcQcQPBhot6Per5zo4lX\n" +
+            "9fQjofJaMTScHj3uC+x11rgup0b3z7sudiIi+oSWQa4AhxGweD+fU6/Tb68pZ+fnh7owPO/Os8Cu\n" +
+            "VujKpvCuJsfqtXMvHAE1+KKFQQGG3A+2cp412XJeQjSHLVkzVQXKOrWn/bljH/nNmslXPa30+nES\n" +
+            "U4/Jikdp0k0CfNhEtNJxmwhCBGsFSWZrolZANmhECYLVQISu9gzFIb8WBhT/+zf3MyVe2DOTbWdo\n" +
+            "LCd+OWSSBGpDCmFNiimjQGLLDQxihSNNmppU3Yd67c0ILksjhOxqsKU3eUsooPvG4kXUrli/MlF7\n" +
+            "dayEU7kb6lepJOxOLAf7XneFmkfCuCp95nh+LdwhfegL8E5l0LzNo4IVlApi0Vy0GZvs9O6b+vHZ\n" +
+            "xzBv0toB3Yuk5lCwuualHs8fSD0/3NqdZ48nBd+5bjYilfNdokZr6zmP7TmY5YwLAIUNq8MbmR8G\n" +
+            "faV9ulfLz1K+3g9j1YCFDeq7aYROMQbwMIvHimNt7/bJCCIX02nj";
+
     @Before
     public void beforeEach() {
         backdoor.restoreDataFromResource(SAMPLE_DATA, LICENCE_FOR_TESTING);

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/test/java/it/com/atlassian/jira/plugins/slack/functional/UnfurlingFuncTest.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/test/java/it/com/atlassian/jira/plugins/slack/functional/UnfurlingFuncTest.java
@@ -10,7 +10,6 @@ import org.junit.Test;
 
 import java.util.List;
 
-import static com.atlassian.jira.testkit.client.util.TimeBombLicence.LICENCE_FOR_TESTING;
 import static com.atlassian.plugins.slack.test.RequestMatchers.hasHit;
 import static com.atlassian.plugins.slack.test.RequestMatchers.requestEntityProperty;
 import static com.github.seratch.jslack.api.methods.Methods.CHAT_UNFURL;
@@ -23,7 +22,7 @@ import static org.hamcrest.Matchers.containsString;
 public class UnfurlingFuncTest extends SlackFunctionalTestBase {
     @Before
     public void beforeEach() {
-        backdoor.restoreDataFromResource(SAMPLE_DATA, LICENCE_FOR_TESTING);
+        backdoor.restoreDataFromResource(SAMPLE_DATA);
     }
 
     @Test

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/test/java/it/com/atlassian/jira/plugins/slack/functional/UserLinkFuncTest.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/test/java/it/com/atlassian/jira/plugins/slack/functional/UserLinkFuncTest.java
@@ -6,7 +6,6 @@ import it.com.atlassian.jira.plugins.slack.util.SlackFunctionalTestBase;
 import org.junit.Before;
 import org.junit.Test;
 
-import static com.atlassian.jira.testkit.client.util.TimeBombLicence.LICENCE_FOR_TESTING;
 import static com.atlassian.plugins.slack.test.TestTeams.DUMMY_TEAM_ID;
 import static it.com.atlassian.jira.plugins.slack.util.JiraFuncTestData.SAMPLE_DATA;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -16,7 +15,7 @@ import static org.hamcrest.Matchers.is;
 public class UserLinkFuncTest extends SlackFunctionalTestBase {
     @Before
     public void beforeEach() {
-        backdoor.restoreDataFromResource(SAMPLE_DATA, LICENCE_FOR_TESTING);
+        backdoor.restoreDataFromResource(SAMPLE_DATA);
     }
 
     @Test

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/test/java/it/com/atlassian/jira/plugins/slack/functional/WorkspaceLinkFuncTest.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/test/java/it/com/atlassian/jira/plugins/slack/functional/WorkspaceLinkFuncTest.java
@@ -6,7 +6,6 @@ import it.com.atlassian.jira.plugins.slack.util.SlackFunctionalTestBase;
 import org.junit.Before;
 import org.junit.Test;
 
-import static com.atlassian.jira.testkit.client.util.TimeBombLicence.LICENCE_FOR_TESTING;
 import static com.atlassian.plugins.slack.test.RequestMatchers.body;
 import static com.atlassian.plugins.slack.test.RequestMatchers.hasHit;
 import static com.atlassian.plugins.slack.test.RequestMatchers.request;
@@ -24,7 +23,7 @@ import static org.hamcrest.Matchers.is;
 public class WorkspaceLinkFuncTest extends SlackFunctionalTestBase {
     @Before
     public void beforeEach() {
-        backdoor.restoreDataFromResource(SAMPLE_DATA, LICENCE_FOR_TESTING);
+        backdoor.restoreDataFromResource(SAMPLE_DATA);
     }
 
     @Test

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/test/java/it/com/atlassian/jira/plugins/slack/web/ConfigurationWebTest.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/test/java/it/com/atlassian/jira/plugins/slack/web/ConfigurationWebTest.java
@@ -19,7 +19,6 @@ import javax.inject.Inject;
 import java.util.List;
 import java.util.Optional;
 
-import static com.atlassian.jira.testkit.client.util.TimeBombLicence.LICENCE_FOR_TESTING;
 import static com.atlassian.plugins.slack.test.RequestMatchers.hasHit;
 import static com.atlassian.plugins.slack.test.RequestMatchers.requestEntityProperty;
 import static com.atlassian.plugins.slack.test.TestChannels.PUBLIC;
@@ -44,7 +43,7 @@ public class ConfigurationWebTest extends SlackWebTestBase {
 
     @Before
     public void beforeEach() {
-        backdoor.restoreDataFromResource(SAMPLE_DATA, LICENCE_FOR_TESTING);
+        backdoor.restoreDataFromResource(SAMPLE_DATA);
         flakyWebTestKiller.disableJiraFlags();
         connectToDummyTeamAndConfirmAdminAccount();
     }


### PR DESCRIPTION
Jira builds fail because of invalid license. Server license is provided in integration tests, but Jira stopped accepting it and now wants DC license only. So that replacing the old one