### PR TITLE
Add replacement annotation alongside deprecated one

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,7 @@
         <atlassian-plugins-webfragment.version>3.0.1</atlassian-plugins-webfragment.version>
         <atlassian-user.version>3.0</atlassian-user.version>
         <template.renderer.version>2.1.0</template.renderer.version>
+        <velocity-htmlsafe.version>4.0.5</velocity-htmlsafe.version>
         <hamcrest-core.version>1.3</hamcrest-core.version>
         <atlassian-concurrent.version>3.0.0</atlassian-concurrent.version>
         <atlassian-json-api.version>0.9</atlassian-json-api.version>
@@ -278,6 +279,11 @@
                 <groupId>com.atlassian.templaterenderer</groupId>
                 <artifactId>atlassian-template-renderer-api</artifactId>
                 <version>${template.renderer.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.atlassian.velocity.htmlsafe</groupId>
+                <artifactId>velocity-htmlsafe</artifactId>
+                <version>${velocity-htmlsafe.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>

--- a/slack-server-integration-common/pom.xml
+++ b/slack-server-integration-common/pom.xml
@@ -84,6 +84,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>com.atlassian.velocity.htmlsafe</groupId>
+            <artifactId>velocity-htmlsafe</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
             <scope>provided</scope>

--- a/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/velocity/VelocityPageBuilderService.java
+++ b/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/velocity/VelocityPageBuilderService.java
@@ -1,6 +1,6 @@
 package com.atlassian.plugins.slack.velocity;
 
-import com.atlassian.templaterenderer.annotations.HtmlSafe;
+import com.atlassian.velocity.htmlsafe.HtmlSafe;
 import com.atlassian.webresource.api.assembler.PageBuilderService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -33,6 +33,7 @@ public class VelocityPageBuilderService {
                 .writeHtmlTags(writer, AUTO);
     }
 
+    @com.atlassian.templaterenderer.annotations.HtmlSafe
     @HtmlSafe
     public String getRequiredResources() {
         StringWriter stringWriter = new StringWriter();


### PR DESCRIPTION
This replacement annotation is required for Confluence 9.0+ and Jira 10.0+ compatibility.