### PR TITLE
Align with latest available products versions

### DIFF
--- a/.github/workflows/all-tests.yml
+++ b/.github/workflows/all-tests.yml
@@ -63,7 +63,7 @@ jobs:
     strategy:
       matrix:
         java-version: [17, 21]
-        jira-version: [10.0.0-m0009]
+        jira-version: [10.0.0-m0010]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -102,7 +102,7 @@ jobs:
       matrix:
         # every version part should be 0 <= <version> <= 255; otherwise Confluence fails to start
         java-version: [17, 21]
-        confluence-version: [9.0.0-rc2]
+        confluence-version: [9.0.1]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -140,7 +140,7 @@ jobs:
     strategy:
       matrix:
         java-version: [17]
-        bitbucket-version: [9.0.0-eap09]
+        bitbucket-version: [9.0.0]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Links to the official documentation are specified on Marketplace pages.
 Supported products. See [EOL policy](https://confluence.atlassian.com/support/atlassian-support-end-of-life-policy-201851003.html).
 * `master`/`dev` branch
   * Jira: 10+ (not released yet) on JDK 17.
-  * Confluence: 9+ (not released yet) on JDK 17.
-  * Bitbucket: 9+ (not released yet) on JDK 17.
+  * Confluence: 9+ on JDK 17.
+  * Bitbucket: 9+ on JDK 17.
 
 * `release-1.x` branch
   * Jira: 8.15.0 (EOL date: 2 Feb 2023) JDK 8, 11 - 9.5.0 (EOL date: 6 Dec 2024) on JDK 8, 11, 17.
@@ -138,12 +138,12 @@ See [all-tests.yml](.github/workflows/all-tests.yml) for more details. A specifi
 Note: all integration test jobs in default workflow (`all-tests.yml`) are dependent on unit tests, so to run integration tests
 for specific product pass the respective job's name along with `unit-test` to `jobs` parameter. For example: `unit-tests,integration-tests-jira-8`.
 
-Integration tests for arbitrary verions of the the product and JVM may be run manually using 
+Integration tests for arbitrary versions of the product and JVM may be run manually using 
 [jira-int-tests.yml](.github/workflows/jira-int-tests.yml), [confluence-int-tests.yml](.github/workflows/confluence-int-tests.yml)
 and [bitbucket-int-tests.yml](.github/workflows/bitbucket-int-tests.yml).
 
 ## Releasing
-Release workflow allows to publish new releases to [Atlassian Artifactory](https://packages.atlassian.com/). 
+Release workflow allows to publish new releases to [GitHub Packages](https://github.com/orgs/atlassian-labs/packages?repo_name=atlassian-slack-integration-server). 
 This action should be usually be run by repo maintainer only. See workflow configuration in [release.yml](.github/workflows/release.yml).
 
 # Contributions

--- a/bin/build/run-confluence-its.sh
+++ b/bin/build/run-confluence-its.sh
@@ -8,8 +8,6 @@ if [[ ${XVFB_ENABLE} != false ]] ; then
     export DISPLAY=:20
 fi
 
-# TODO: Remove -Denforcer.skip=true after moving from milestone versions
-
 atlas-mvn --batch-mode verify \
   ${VERSION_ARG} \
   -Dut.test.skip=true \
@@ -20,6 +18,5 @@ atlas-mvn --batch-mode verify \
   -Dfailsafe.rerunFailingTestsCount=${RETRY_COUNT:-2} \
   -Dfailsafe.forkedProcessExitTimeoutInSeconds=360 \
   -Dfailsafe.exitTimeout=360 \
-  -Denforcer.skip=true \
   -pl confluence-slack-integration/confluence-slack-server-integration-plugin \
   "$@"

--- a/bin/build/run-unit-tests.sh
+++ b/bin/build/run-unit-tests.sh
@@ -2,7 +2,5 @@
 set -ex
 trap 'set +ex' EXIT
 
-# TODO: Remove -Denforcer.skip=true after moving from milestone versions
-
 atlas-version
-atlas-mvn --batch-mode verify -P jacoco -Denforcer.skip=true
+atlas-mvn --batch-mode verify -P jacoco

--- a/bin/run-bitbucket.sh
+++ b/bin/run-bitbucket.sh
@@ -7,15 +7,12 @@ trap 'set +ex' EXIT
 BB_NGROK="$(curl -s "http://127.0.0.1:4040/api/tunnels" | \
   jq -r '.tunnels[] | select(.proto == "https") | select (.config.addr|endswith("'"7990"'")) | .public_url[8:]')"
 
-# TODO: Remove -Denforcer.skip=true after moving from milestone versions
-
 (
     cd "$( dirname "${BASH_SOURCE[0]}")/.." ;
 
     # set env var BB_NGROK to enable HTTPS
 
     atlas-mvn bitbucket:debug \
-        -Denforcer.skip=true \
         -Datlassian.dev.mode=true \
         -Dmaven.test.skip=true \
         -Dlogging.level.com.atlassian.bitbucket.plugins.slack=TRACE \

--- a/bin/run-confluence.sh
+++ b/bin/run-confluence.sh
@@ -1,11 +1,8 @@
 #!/usr/bin/env bash
 
-# TODO: Remove -Denforcer.skip=true after moving from milestone versions
-
 (
     cd "$( dirname "${BASH_SOURCE[0]}")/.." ;
     atlas-mvn confluence:debug \
-        -Denforcer.skip=true \
         -Datlassian.dev.mode=true \
         -Dmaven.test.skip=true \
         "$@" \

--- a/confluence-slack-integration/confluence-slack-server-integration-plugin/pom.xml
+++ b/confluence-slack-integration/confluence-slack-server-integration-plugin/pom.xml
@@ -28,7 +28,7 @@
         <confluence.version>9.0.1</confluence.version>
         <confluence.data.version>${confluence.version}</confluence.data.version>
 
-        <confluence.amps.version>8.9.2</confluence.amps.version>
+        <confluence.amps.version>9.0.4</confluence.amps.version>
         <jvm17.opens />
     </properties>
 
@@ -325,6 +325,11 @@
                     <skipManifestValidation>true</skipManifestValidation>
                     <forceUpdateCheck>false</forceUpdateCheck>
                     <skipAllPrompts>true</skipAllPrompts>
+
+                    <banningExcludes>
+                        <exclude>com.atlassian.security:atlassian-secure-random</exclude>
+                        <exclude>com.google.code.gson:gson</exclude>
+                    </banningExcludes>
 
                     <!-- Custom logging config to show logs from plugin classes by default -->
                     <log4jProperties>src/main/resources/log4j.properties</log4jProperties>

--- a/jira-slack-server-integration/pom.xml
+++ b/jira-slack-server-integration/pom.xml
@@ -22,12 +22,12 @@
         <aui.version>5.1.3</aui.version>
 
         <!-- this is the version we will run integration tests against -->
-        <jira.version>10.0.0-m0009</jira.version>
+        <jira.version>10.0.0-m0010</jira.version>
         <testkit.version>10.0.3</testkit.version>
         <jira.test.unit.version>${jira.version}</jira.test.unit.version>
 
         <!-- This is the version the plugin is compiled against -->
-        <jira.compile.version>10.0.0-m0009</jira.compile.version>
+        <jira.compile.version>10.0.0-m0010</jira.compile.version>
 
         <jira.pageobjects.version>${jira.version}</jira.pageobjects.version>
 


### PR DESCRIPTION
- Bump Confluence AMPS plugin version to 9.0.4
- Bump Jira version to 10.0.0-m0010
- Remove `enforcer.skip=true` flags