### PR TITLE
Bump dependencies and fix tests against new products' releases

### DIFF
--- a/bitbucket-slack-server-integration-plugin/pom.xml
+++ b/bitbucket-slack-server-integration-plugin/pom.xml
@@ -35,22 +35,21 @@
         <project.scm.id>github</project.scm.id>
 
         <!-- dependency versions -->
-        <atlassian.spring.scanner.version>5.0.0</atlassian.spring.scanner.version>
+        <atlassian.spring.scanner.version>5.1.0</atlassian.spring.scanner.version>
         <junit.jupiter.version>5.7.1</junit.jupiter.version>
         <mockito-core.version>2.25.0</mockito-core.version>
-        <atlassian.selenium.version>3.0.0</atlassian.selenium.version>
+        <atlassian.selenium.version>3.6.0</atlassian.selenium.version>
         <commons-codec.version>1.11</commons-codec.version>
         <slack.common.version>2.0.0</slack.common.version>
 
         <!-- product properties -->
         <plugin.key>${project.groupId}.${project.artifactId}</plugin.key>
         <!-- TODO: 9.0.0 bitbucket-rest-api and bitbucket-rest-model are not available yet-->
-        <bitbucket.rest.api.version>9.0.0-eap09</bitbucket.rest.api.version>
-        <bitbucket.api.version>9.0.0</bitbucket.api.version>
+        <bitbucket.rest.api.version>9.0.0-plat-7-m20</bitbucket.rest.api.version>
         <bitbucket.version>9.0.0</bitbucket.version>
         <bitbucket.data.version>${bitbucket.version}</bitbucket.data.version>
-        <bitbucket.amps.version>9.0.4</bitbucket.amps.version>
-        <platform.version>7.0.5</platform.version>
+        <bitbucket.amps.version>9.1.11</bitbucket.amps.version>
+        <platform.version>7.2.6</platform.version>
     </properties>
 
     <dependencyManagement>
@@ -116,13 +115,13 @@
         <dependency>
             <groupId>com.atlassian.bitbucket.server</groupId>
             <artifactId>bitbucket-ao-common</artifactId>
-            <version>${bitbucket.api.version}</version>
+            <version>${bitbucket.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.atlassian.bitbucket.server</groupId>
             <artifactId>bitbucket-api</artifactId>
-            <version>${bitbucket.api.version}</version>
+            <version>${bitbucket.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -140,19 +139,19 @@
         <dependency>
             <groupId>com.atlassian.bitbucket.server</groupId>
             <artifactId>bitbucket-git-api</artifactId>
-            <version>${bitbucket.api.version}</version>
+            <version>${bitbucket.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.atlassian.bitbucket.server</groupId>
             <artifactId>bitbucket-util</artifactId>
-            <version>${bitbucket.api.version}</version>
+            <version>${bitbucket.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.atlassian.bitbucket.server</groupId>
             <artifactId>bitbucket-scm-common</artifactId>
-            <version>${bitbucket.api.version}</version>
+            <version>${bitbucket.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -342,7 +341,7 @@
         <dependency>
             <groupId>net.bytebuddy</groupId>
             <artifactId>byte-buddy</artifactId>
-            <version>1.14.18</version>
+            <version>1.14.19</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -473,6 +472,7 @@
                     <instanceId>bitbucket</instanceId>
                     <productVersion>${bitbucket.version}</productVersion>
                     <productDataVersion>${bitbucket.data.version}</productDataVersion>
+                    <server>localhost</server>
                     <skipITs>${it.test.skip}</skipITs>
                     <skipUTs>${ut.test.skip}</skipUTs>
                     <noWebapp>${app.startup.skip}</noWebapp>
@@ -484,6 +484,7 @@
                     <skipManifestValidation>true</skipManifestValidation>
                     <forceUpdateCheck>false</forceUpdateCheck>
                     <skipAllPrompts>true</skipAllPrompts>
+                    <verifyFeManifestAssociationsFailOnUndeclaredFiles>false</verifyFeManifestAssociationsFailOnUndeclaredFiles>
 
                     <!-- It allows to connect to Bitbucket embedded database while it is running -->
                     <jvmArgs>${jvm17.opens} -Djdbc.url=jdbc:h2:${project.build.directory}/bitbucket/home/shared/data/db;DB_CLOSE_DELAY=-1;AUTO_SERVER=TRUE</jvmArgs>
@@ -507,6 +508,7 @@
                         <!-- Discovery is disabled by default -->
                         <discovery.test.mode>true</discovery.test.mode>
                         <atlassian.test.target.dir>${project.build.directory}/webdriverTests</atlassian.test.target.dir>
+                        <atlassian.authentication.legacy.mode>true</atlassian.authentication.legacy.mode>
                     </systemPropertyVariables>
 
                     <instructions>

--- a/confluence-slack-integration/confluence-slack-server-integration-plugin/pom.xml
+++ b/confluence-slack-integration/confluence-slack-server-integration-plugin/pom.xml
@@ -21,14 +21,10 @@
 
         <project.root.directory>${project.basedir}/..</project.root.directory>
 
-        <!-- version of Confluence libraries used to compile plugin code -->
-        <confluence.api.version>9.0.1</confluence.api.version>
-
-        <!-- version of Confluence used in integration tests -->
-        <confluence.version>9.0.1</confluence.version>
+        <confluence.version>9.0.3</confluence.version>
         <confluence.data.version>${confluence.version}</confluence.data.version>
 
-        <confluence.amps.version>9.0.4</confluence.amps.version>
+        <confluence.amps.version>${amps.version}</confluence.amps.version>
         <jvm17.opens />
     </properties>
 
@@ -87,7 +83,7 @@
         <dependency>
             <groupId>com.atlassian.confluence</groupId>
             <artifactId>confluence</artifactId>
-            <version>${confluence.api.version}</version>
+            <version>${confluence.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -263,34 +259,8 @@
         <dependency>
             <groupId>com.atlassian.confluence</groupId>
             <artifactId>confluence-webdriver-pageobjects</artifactId>
-            <version>11.5.2</version>
+            <version>12.2.6</version>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <artifactId>junit</artifactId>
-                    <groupId>junit</groupId>
-                </exclusion>
-                <exclusion>
-                    <artifactId>junit-dep</artifactId>
-                    <groupId>junit</groupId>
-                </exclusion>
-                <exclusion>
-                    <groupId>javax.ws.rs</groupId>
-                    <artifactId>jsr311-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.sun.jersey</groupId>
-                    <artifactId>jersey-client</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.sun.jersey</groupId>
-                    <artifactId>jersey-core</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.atlassian.plugins</groupId>
-                    <artifactId>atlassian-plugins-api</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>commons-lang</groupId>
@@ -314,6 +284,7 @@
                 <configuration>
                     <productVersion>${confluence.version}</productVersion>
                     <productDataVersion>${confluence.data.version}</productDataVersion>
+                    <server>localhost</server>
                     <skipITs>${it.test.skip}</skipITs>
                     <skipUTs>${ut.test.skip}</skipUTs>
                     <noWebapp>${app.startup.skip}</noWebapp>
@@ -325,10 +296,12 @@
                     <skipManifestValidation>true</skipManifestValidation>
                     <forceUpdateCheck>false</forceUpdateCheck>
                     <skipAllPrompts>true</skipAllPrompts>
+                    <verifyFeManifestAssociationsFailOnUndeclaredFiles>false</verifyFeManifestAssociationsFailOnUndeclaredFiles>
 
                     <banningExcludes>
                         <exclude>com.atlassian.security:atlassian-secure-random</exclude>
                         <exclude>com.google.code.gson:gson</exclude>
+                        <exclude>net.bytebuddy:byte-buddy</exclude>
                     </banningExcludes>
 
                     <!-- Custom logging config to show logs from plugin classes by default -->
@@ -354,6 +327,7 @@
                         <synchrony.proxy.enabled>false</synchrony.proxy.enabled>
                         <!-- This disables the Post Upgrade Landing Page, which we never want showing up in tests -->
                         <atlassian.darkfeature.pulp>false</atlassian.darkfeature.pulp>
+                        <atlassian.authentication.legacy.mode>true</atlassian.authentication.legacy.mode>
                     </systemPropertyVariables>
                     <instructions>
                         <CONF_COMM />

--- a/confluence-slack-integration/confluence-slack-server-integration-plugin/src/test/java/it/com/atlassian/confluence/plugins/slack/util/SlackWebTestBase.java
+++ b/confluence-slack-integration/confluence-slack-server-integration-plugin/src/test/java/it/com/atlassian/confluence/plugins/slack/util/SlackWebTestBase.java
@@ -11,6 +11,7 @@ import com.atlassian.webdriver.testing.rule.WindowSizeRule;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.openqa.selenium.By;
+import org.openqa.selenium.ElementNotInteractableException;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
@@ -59,7 +60,7 @@ public abstract class SlackWebTestBase extends SlackFunctionalTestBase {
         for (WebElement flag : flags) {
             try {
                 flag.findElement(By.className("aui-close-button")).click();
-            } catch (NoSuchElementException e) {
+            } catch (NoSuchElementException | ElementNotInteractableException e) {
                 // ignore intentionally; the flag is already closed
             }
         }

--- a/confluence-slack-integration/confluence-slack-server-integration-plugin/src/test/java/it/com/atlassian/confluence/plugins/slack/web/ConfigurationWebTest.java
+++ b/confluence-slack-integration/confluence-slack-server-integration-plugin/src/test/java/it/com/atlassian/confluence/plugins/slack/web/ConfigurationWebTest.java
@@ -26,6 +26,7 @@ import static com.github.seratch.jslack.api.methods.Methods.CHAT_POST_MESSAGE;
 import static com.github.seratch.jslack.api.methods.Methods.CONVERSATIONS_INVITE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
@@ -61,8 +62,11 @@ public class ConfigurationWebTest extends SlackWebTestBase {
         });
 
         assertThat(server.requestHistoryForTest(), hasHit(CHAT_POST_MESSAGE, contains(
-                requestEntityProperty(ChatPostMessageRequest::getText, containsString(
-                        "set Confluence notifications from space *<http://example.com/context/display/IT?atlLinkOrigin=c2xhY2staW50ZWdyYXRpb258c3BhY2U%3D|IT Space>* to appear in this channel."))
+                requestEntityProperty(ChatPostMessageRequest::getText, anyOf(
+                        containsString("set Confluence notifications from space *<http://example.com/context/display/IT?atlLinkOrigin=c2xhY2staW50ZWdyYXRpb258c3BhY2U%3D|IT Space>* to appear in this channel."),
+                        // Since Confluence 9.1 there is enabled `confluence.readable.url` feature causing Space#getUrlPath() to return `spaces/{space_name}/overview`
+                        containsString("set Confluence notifications from space *<http://example.com/context/spaces/IT/overview?atlLinkOrigin=c2xhY2staW50ZWdyYXRpb258c3BhY2U%3D|IT Space>* to appear in this channel.")
+                ))
         )));
 
         assertThat(server.requestHistoryForTest(), hasHit(CONVERSATIONS_INVITE, contains(allOf(

--- a/jira-slack-server-integration/jira-8-compat/pom.xml
+++ b/jira-slack-server-integration/jira-8-compat/pom.xml
@@ -55,7 +55,6 @@
         <dependency>
             <groupId>net.bytebuddy</groupId>
             <artifactId>byte-buddy</artifactId>
-            <version>1.14.18</version>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/pom.xml
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/pom.xml
@@ -376,6 +376,7 @@
                     <instanceId>jira</instanceId>
                     <productVersion>${jira.version}</productVersion>
                     <productDataVersion>${jira.data.version}</productDataVersion>
+                    <server>localhost</server>
                     <skipITs>${it.test.skip}</skipITs>
                     <skipUTs>${ut.test.skip}</skipUTs>
                     <noWebapp>${app.startup.skip}</noWebapp>
@@ -387,6 +388,7 @@
                     <skipManifestValidation>true</skipManifestValidation>
                     <forceUpdateCheck>false</forceUpdateCheck>
                     <skipAllPrompts>true</skipAllPrompts>
+                    <verifyFeManifestAssociationsFailOnUndeclaredFiles>false</verifyFeManifestAssociationsFailOnUndeclaredFiles>
 
                     <!-- Custom logging config to show logs from plugin classes by default -->
                     <log4jProperties>src/main/resources/log4j.properties</log4jProperties>
@@ -399,6 +401,7 @@
                         <exclude>com.atlassian.security:atlassian-secure-random</exclude>
                         <exclude>commons-codec:commons-codec</exclude>
                         <exclude>com.google.code.gson:gson</exclude>
+                        <exclude>net.bytebuddy:byte-buddy</exclude>
                     </banningExcludes>
 
                     <pluginArtifacts>
@@ -428,6 +431,7 @@
                         <!-- Discovery is disabled by default -->
                         <discovery.test.mode>true</discovery.test.mode>
                         <atlassian.test.target.dir>${project.build.directory}/webdriverTests</atlassian.test.target.dir>
+                        <atlassian.authentication.legacy.mode>true</atlassian.authentication.legacy.mode>
                     </systemPropertyVariables>
 
                     <instructions>
@@ -646,7 +650,7 @@
     </build>
 
     <properties>
-        <jira.amps.version>9.0.3</jira.amps.version>
+        <jira.amps.version>${amps.version}</jira.amps.version>
         <project.root.directory>${project.basedir}/../..</project.root.directory>
         <maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ss.SSSZ</maven.build.timestamp.format>
         <build.timestamp>${maven.build.timestamp}</build.timestamp>

--- a/jira-slack-server-integration/pom.xml
+++ b/jira-slack-server-integration/pom.xml
@@ -25,12 +25,7 @@
         <jira.version>10.0.0</jira.version>
         <testkit.version>10.0.3</testkit.version>
         <jira.test.unit.version>${jira.version}</jira.test.unit.version>
-
-        <!-- This is the version the plugin is compiled against -->
-        <jira.compile.version>10.0.0</jira.compile.version>
-
         <jira.pageobjects.version>${jira.version}</jira.pageobjects.version>
-
         <jira.data.version>${jira.version}</jira.data.version>
         <jira-project-config.version>${jira.version}</jira-project-config.version>
         <triggers.version>2.3.8</triggers.version>
@@ -53,7 +48,7 @@
             <dependency>
                 <groupId>com.atlassian.jira</groupId>
                 <artifactId>jira-api</artifactId>
-                <version>${jira.compile.version}</version>
+                <version>${jira.version}</version>
                 <exclusions>
                     <!-- Old version of the Jackson bundled into Jira. We bundle newer Jackson implementation -->
                     <exclusion>
@@ -73,7 +68,7 @@
             <dependency>
                 <groupId>com.atlassian.jira</groupId>
                 <artifactId>jira-core</artifactId>
-                <version>${jira.compile.version}</version>
+                <version>${jira.version}</version>
                 <exclusions>
                     <exclusion>
                         <artifactId>fugue</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,6 @@
         <junit.version>4.13.2</junit.version>
         <junit.jupiter.version>5.7.1</junit.jupiter.version>
         <joda-time.version>2.3</joda-time.version>
-        <commons-lang3.version>3.8</commons-lang3.version>
         <commons-codec.version>1.11</commons-codec.version>
         <ao.version>6.0.0</ao.version>
         <okhttp.version>4.10.0</okhttp.version>
@@ -60,7 +59,8 @@
         <powermock.version>2.0.2</powermock.version>
 
         <slack.common.version>2.0.0</slack.common.version>
-        <platform.version>7.0.0</platform.version>
+        <platform.version>7.2.6</platform.version>
+        <amps.version>9.1.11</amps.version>
         <jvm17.opens />
     </properties>
 
@@ -253,11 +253,6 @@
                         <groupId>net.java.dev.activeobjects</groupId>
                     </exclusion>
                 </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-lang3</artifactId>
-                <version>${commons-lang3.version}</version>
             </dependency>
             <dependency>
                 <groupId>commons-lang</groupId>

--- a/slack-server-integration-common/pom.xml
+++ b/slack-server-integration-common/pom.xml
@@ -66,6 +66,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>com.atlassian.sal</groupId>
             <artifactId>sal-api</artifactId>
             <scope>provided</scope>
@@ -237,7 +242,6 @@
         <dependency>
             <groupId>net.bytebuddy</groupId>
             <artifactId>byte-buddy</artifactId>
-            <version>1.14.18</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Bump AMPS plugins to 9.1.11.
Update platform to 7.2.6.
Add `atlassian.authentication.legacy.mode` property 
Disable verify-fe-manifest-associations.