### PR TITLE
Adding support for the search API migration

### DIFF
--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/bridge/jql/impl/JqlIndexSearcher.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/bridge/jql/impl/JqlIndexSearcher.java
@@ -3,22 +3,20 @@ package com.atlassian.jira.plugins.slack.bridge.jql.impl;
 import com.atlassian.jira.issue.Issue;
 import com.atlassian.jira.issue.index.ThreadLocalSearcherCache;
 import com.atlassian.jira.issue.search.SearchException;
-import com.atlassian.jira.issue.search.SearchProvider;
-import com.atlassian.jira.issue.search.SearchQuery;
 import com.atlassian.jira.jql.builder.JqlQueryBuilder;
 import com.atlassian.jira.plugins.slack.bridge.jql.JqlSearcher;
 import com.atlassian.jira.plugins.slack.compat.FixRequestTypeClauseVisitor;
 import com.atlassian.jira.project.Project;
+import com.atlassian.jira.search.issue.IssueDocumentSearchService;
 import com.atlassian.jira.user.ApplicationUser;
 import com.atlassian.query.Query;
 import com.atlassian.query.clause.Clause;
+import javax.annotation.Nullable;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-
-import javax.annotation.Nullable;
 
 /**
  * This jql index searcher commits the issue to the FS and runs the query.
@@ -28,7 +26,7 @@ import javax.annotation.Nullable;
 public class JqlIndexSearcher implements JqlSearcher {
     private static final Logger log = LoggerFactory.getLogger(JqlIndexSearcher.class);
 
-    private final SearchProvider searchProvider;
+    private final IssueDocumentSearchService issueDocumentSearchService;
 
     @Override
     public Boolean doesIssueMatchQuery(final Issue issue,
@@ -39,11 +37,8 @@ public class JqlIndexSearcher implements JqlSearcher {
             long searchCount;
 
             Query fixedQuery = fixRequestTypeInQuery(query, issue.getProjectObject());
-            SearchQuery searchQuery = SearchQuery.create(fixedQuery, caller);
-            if (caller == null) {
-                searchQuery.overrideSecurity(true);
-            }
-            searchCount = searchProvider.getHitCount(searchQuery);
+
+            searchCount = issueDocumentSearchService.getHitCount(caller, fixedQuery, caller == null);
 
             return searchCount > 0;
         } catch (SearchException e) {
@@ -68,12 +63,12 @@ public class JqlIndexSearcher implements JqlSearcher {
         if (visitor.isClauseChanged()) {
             log.debug("JQL query before fixing a request type: [{}]", query.toString());
             fixedQuery = JqlQueryBuilder.newBuilder()
-                    .where()
-                    .addClause(fixedWhereClause)
-                    .endWhere()
-                    .orderBy()
-                    .setSorts(query.getOrderByClause())
-                    .buildQuery();
+                .where()
+                .addClause(fixedWhereClause)
+                .endWhere()
+                .orderBy()
+                .setSorts(query.getOrderByClause())
+                .buildQuery();
             log.debug("JQL query after fixing a request type: [{}]", fixedQuery.toString());
         }
 

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/service/ComponentImports.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/service/ComponentImports.java
@@ -16,10 +16,10 @@ import com.atlassian.jira.issue.IssueManager;
 import com.atlassian.jira.issue.comments.CommentManager;
 import com.atlassian.jira.issue.fields.FieldManager;
 import com.atlassian.jira.issue.index.IssueIndexingService;
-import com.atlassian.jira.issue.search.SearchProvider;
 import com.atlassian.jira.issue.watchers.WatcherManager;
 import com.atlassian.jira.project.ProjectManager;
 import com.atlassian.jira.projectconfig.util.ProjectConfigRequestCache;
+import com.atlassian.jira.search.issue.IssueDocumentSearchService;
 import com.atlassian.jira.security.GlobalPermissionManager;
 import com.atlassian.jira.security.JiraAuthenticationContext;
 import com.atlassian.jira.security.PermissionManager;
@@ -61,7 +61,7 @@ public class ComponentImports {
     @ComponentImport
     I18nResolver i18nResolver;
     @ComponentImport
-    SearchProvider searchProvider;
+    IssueDocumentSearchService issueDocumentSearchService;
     @ComponentImport
     BuildUtilsInfo buildUtilsInfo;
     @ComponentImport

--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/test/java/com/atlassian/jira/plugins/slack/bridge/jql/impl/JqlIndexSearcherTest.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/test/java/com/atlassian/jira/plugins/slack/bridge/jql/impl/JqlIndexSearcherTest.java
@@ -1,12 +1,10 @@
 package com.atlassian.jira.plugins.slack.bridge.jql.impl;
 
 import com.atlassian.jira.issue.Issue;
-import com.atlassian.jira.issue.index.IssueIndexingParams;
-import com.atlassian.jira.issue.index.IssueIndexingService;
-import com.atlassian.jira.issue.search.SearchProvider;
-import com.atlassian.jira.issue.search.SearchQuery;
+import com.atlassian.jira.search.issue.IssueDocumentSearchService;
 import com.atlassian.jira.user.ApplicationUser;
 import com.atlassian.query.Query;
+import java.util.concurrent.Callable;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -16,16 +14,13 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
-import java.util.concurrent.Callable;
-
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class JqlIndexSearcherTest {
     @Mock
-    private SearchProvider searchProvider;
+    private IssueDocumentSearchService issueDocumentSearchService;
 
     @Mock
     private ApplicationUser applicationUser;
@@ -45,7 +40,7 @@ public class JqlIndexSearcherTest {
 
     @Test
     public void doesIssueMatchQuery_shouldReturnTrueIfSearchCountGreaterThanZero() throws Exception {
-        when(searchProvider.getHitCount(SearchQuery.create(query, applicationUser))).thenReturn(1L);
+        when(issueDocumentSearchService.getHitCount(applicationUser, query, false)).thenReturn(1L);
 
         boolean result = target.doesIssueMatchQuery(issue, applicationUser, query);
 
@@ -54,7 +49,7 @@ public class JqlIndexSearcherTest {
 
     @Test
     public void doesIssueMatchQuery_shouldReturnFalseIfSearchCountIsZero() throws Exception {
-        when(searchProvider.getHitCount(SearchQuery.create(query, applicationUser))).thenReturn(0L);
+        when(issueDocumentSearchService.getHitCount(applicationUser, query, false)).thenReturn(0L);
 
         boolean result = target.doesIssueMatchQuery(issue, applicationUser, query);
 
@@ -63,7 +58,7 @@ public class JqlIndexSearcherTest {
 
     @Test
     public void doesIssueMatchQuery_shouldReturnTrueIfSearchCountOverrideSecurityGreaterThanZero() throws Exception {
-        when(searchProvider.getHitCount(SearchQuery.create(query, null).overrideSecurity(true))).thenReturn(1L);
+        when(issueDocumentSearchService.getHitCount(null, query, true)).thenReturn(1L);
 
         boolean result = target.doesIssueMatchQuery(issue, null, query);
 
@@ -72,7 +67,7 @@ public class JqlIndexSearcherTest {
 
     @Test
     public void doesIssueMatchQuery_shouldReturnFalseIfSearchOverrideSecurityCountIsZero() throws Exception {
-        when(searchProvider.getHitCount(SearchQuery.create(query, applicationUser))).thenReturn(0L);
+        when(issueDocumentSearchService.getHitCount(applicationUser, query, false)).thenReturn(0L);
 
         boolean result = target.doesIssueMatchQuery(issue, null, query);
 

--- a/jira-slack-server-integration/pom.xml
+++ b/jira-slack-server-integration/pom.xml
@@ -22,7 +22,7 @@
         <aui.version>5.1.3</aui.version>
 
         <!-- this is the version we will run integration tests against -->
-        <jira.version>10.0.0</jira.version>
+        <jira.version>10.7.0-QR-20250522042702</jira.version>
         <testkit.version>10.0.3</testkit.version>
         <jira.test.unit.version>${jira.version}</jira.test.unit.version>
         <jira.pageobjects.version>${jira.version}</jira.pageobjects.version>


### PR DESCRIPTION
This handles the migration from using the SearchProvider to using the new Search API IssueDocumentSearchService which is a breaking change for Jira 11. 