### PR TITLE
Separate product's api version and version used for integration tests

### DIFF
--- a/bitbucket-slack-server-integration-plugin/pom.xml
+++ b/bitbucket-slack-server-integration-plugin/pom.xml
@@ -22,7 +22,7 @@
         <maven.compiler.target>17</maven.compiler.target>
         <jvm17.opens />
 
-        <!-- default properties. copied from parent POM in order to allow to resolve plugin plugin dependencies during BBS build -->
+        <!-- default properties. copied from parent POM in order to allow to resolve plugin dependencies during BBS build -->
         <it.test.skip>true</it.test.skip>
         <ut.test.skip>false</ut.test.skip>
         <app.startup.skip>false</app.startup.skip>
@@ -34,24 +34,31 @@
         <!-- Use credentials of 'github' server from settings.xml during the release -->
         <project.scm.id>github</project.scm.id>
 
-        <!-- dependency versions -->
-        <atlassian.spring.scanner.version>5.1.0</atlassian.spring.scanner.version>
-        <junit.jupiter.version>5.7.1</junit.jupiter.version>
-        <mockito-core.version>2.25.0</mockito-core.version>
-        <atlassian.selenium.version>3.6.0</atlassian.selenium.version>
-        <commons-codec.version>1.11</commons-codec.version>
-        <slack.common.version>2.0.0</slack.common.version>
-
-        <!-- product properties -->
+        <!-- AMPS related properties -->
         <plugin.key>${project.groupId}.${project.artifactId}</plugin.key>
+        <bitbucket.amps.version>9.1.11</bitbucket.amps.version>
+
+        <!-- Bitbucket API version used during the build -->
+        <bitbucket.api.version>9.0.0</bitbucket.api.version>
         <!-- TODO: 9.0.0 bitbucket-rest-api and bitbucket-rest-model are not available yet-->
         <bitbucket.rest.api.version>9.0.0-plat-7-m20</bitbucket.rest.api.version>
+
+        <!-- Bitbucket version used for integration tests; can be overridden to test against different versions -->
         <bitbucket.version>9.0.0</bitbucket.version>
+        <bitbucket.data.version>${bitbucket.version}</bitbucket.data.version>
         <!-- Starting from 9.3+ BitbucketLoginPage fails to find web elements -->
         <bitbucket.page.objects.version>9.0.0</bitbucket.page.objects.version>
-        <bitbucket.amps.version>9.1.11</bitbucket.amps.version>
-        <bitbucket.data.version>${bitbucket.version}</bitbucket.data.version>
+
+        <!-- Platform version used for dependency management -->
         <platform.version>7.2.6</platform.version>
+
+        <!-- Dependency versions -->
+        <atlassian.spring.scanner.version>5.1.0</atlassian.spring.scanner.version>
+        <atlassian.selenium.version>3.6.0</atlassian.selenium.version>
+        <junit.jupiter.version>5.7.1</junit.jupiter.version>
+        <mockito-core.version>2.25.0</mockito-core.version>
+        <commons-codec.version>1.11</commons-codec.version>
+        <slack.common.version>2.0.0</slack.common.version>
     </properties>
 
     <dependencyManagement>
@@ -124,13 +131,13 @@
         <dependency>
             <groupId>com.atlassian.bitbucket.server</groupId>
             <artifactId>bitbucket-ao-common</artifactId>
-            <version>${bitbucket.version}</version>
+            <version>${bitbucket.api.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.atlassian.bitbucket.server</groupId>
             <artifactId>bitbucket-api</artifactId>
-            <version>${bitbucket.version}</version>
+            <version>${bitbucket.api.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -148,19 +155,19 @@
         <dependency>
             <groupId>com.atlassian.bitbucket.server</groupId>
             <artifactId>bitbucket-git-api</artifactId>
-            <version>${bitbucket.version}</version>
+            <version>${bitbucket.api.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.atlassian.bitbucket.server</groupId>
             <artifactId>bitbucket-util</artifactId>
-            <version>${bitbucket.version}</version>
+            <version>${bitbucket.api.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.atlassian.bitbucket.server</groupId>
             <artifactId>bitbucket-scm-common</artifactId>
-            <version>${bitbucket.version}</version>
+            <version>${bitbucket.api.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/confluence-slack-integration/confluence-slack-server-integration-plugin/pom.xml
+++ b/confluence-slack-integration/confluence-slack-server-integration-plugin/pom.xml
@@ -15,17 +15,21 @@
     <description>This is the Slack integration for Confluence Data Center</description>
 
     <properties>
-        <plugin.key>${project.groupId}.${project.artifactId}</plugin.key>
+        <project.root.directory>${project.basedir}/..</project.root.directory>
         <maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ss.SSSZ</maven.build.timestamp.format>
         <build.timestamp>${maven.build.timestamp}</build.timestamp>
+        <jvm17.opens />
 
-        <project.root.directory>${project.basedir}/..</project.root.directory>
+        <!-- AMPS related properties -->
+        <plugin.key>${project.groupId}.${project.artifactId}</plugin.key>
+        <confluence.amps.version>${amps.version}</confluence.amps.version>
 
+        <!-- Confluence version used for integration tests; can be overridden to test against different versions -->
         <confluence.version>9.0.3</confluence.version>
         <confluence.data.version>${confluence.version}</confluence.data.version>
 
-        <confluence.amps.version>${amps.version}</confluence.amps.version>
-        <jvm17.opens />
+        <!-- Confluence API version used during the build -->
+        <confluence.api.version>9.0.3</confluence.api.version>
     </properties>
 
     <dependencies>
@@ -83,7 +87,7 @@
         <dependency>
             <groupId>com.atlassian.confluence</groupId>
             <artifactId>confluence</artifactId>
-            <version>${confluence.version}</version>
+            <version>${confluence.api.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/jira-slack-server-integration/pom.xml
+++ b/jira-slack-server-integration/pom.xml
@@ -19,24 +19,29 @@
     </modules>
 
     <properties>
-        <aui.version>5.1.3</aui.version>
+        <project.root.directory>${project.basedir}/..</project.root.directory>
 
-        <!-- this is the version we will run integration tests against -->
+        <!-- Jira version used for integration tests; can be overridden to test against different versions -->
         <jira.version>10.0.0</jira.version>
+        <jira.data.version>${jira.version}</jira.data.version>
+
+        <!-- Dependencies and plugins that must align with the running Jira during integration tests -->
         <testkit.version>10.3.5</testkit.version>
         <!-- jira-testkit-client 10.3.5 transitively brings publicly unavailable jira-rest-api version -->
         <jira.rest.api.version>10.5.1</jira.rest.api.version>
         <jira.test.unit.version>${jira.version}</jira.test.unit.version>
         <jira.pageobjects.version>${jira.version}</jira.pageobjects.version>
-        <jira.data.version>${jira.version}</jira.data.version>
-        <jira-project-config.version>${jira.version}</jira-project-config.version>
+
+        <!-- Jira API version used during the build -->
+        <jira.api.version>10.0.0</jira.api.version>
+        <!-- Dependencies that must align with the API version used during the build -->
+        <jira-project-config.version>${jira.api.version}</jira-project-config.version>
+
+        <!-- Other dependencies -->
+        <atlassian.vcache.version>1.4.0</atlassian.vcache.version>
         <triggers.version>2.3.8</triggers.version>
         <httpclient.version>0.15.0</httpclient.version>
         <httpclient-core.version>4.3.2</httpclient-core.version>
-
-        <atlassian.vcache.version>1.4.0</atlassian.vcache.version>
-
-        <project.root.directory>${project.basedir}/..</project.root.directory>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Integration tests against latest products:
- Bitbucket 9.6.3 - https://github.com/atlassian-labs/atlassian-slack-integration-server/actions/runs/15946981591
- Confluence 9.5.1 - https://github.com/atlassian-labs/atlassian-slack-integration-server/actions/runs/15946971020
- Jira 10.7.1 - https://github.com/atlassian-labs/atlassian-slack-integration-server/actions/runs/15946951395