### PR TITLE
Swap AnonymousSiteAccess for UnrestrictedAccess

### DIFF
--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/web/rest/PluginInfoResource.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/main/java/com/atlassian/jira/plugins/slack/web/rest/PluginInfoResource.java
@@ -1,7 +1,7 @@
 package com.atlassian.jira.plugins.slack.web.rest;
 
 import com.atlassian.jira.plugins.slack.system.PluginInfoSource;
-import com.atlassian.plugins.rest.api.security.annotation.AnonymousSiteAccess;
+import com.atlassian.plugins.rest.api.security.annotation.UnrestrictedAccess;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
@@ -13,7 +13,7 @@ import javax.ws.rs.core.Response;
 /**
  * Rest Endpoint that will let us validate the configuration of the plugin
  */
-@AnonymousSiteAccess
+@UnrestrictedAccess
 @Path("/info")
 @Consumes({MediaType.APPLICATION_JSON})
 @Produces({MediaType.APPLICATION_JSON})

--- a/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/rest/SlackSettingsRedirectResource.java
+++ b/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/rest/SlackSettingsRedirectResource.java
@@ -1,6 +1,6 @@
 package com.atlassian.plugins.slack.rest;
 
-import com.atlassian.plugins.rest.api.security.annotation.AnonymousSiteAccess;
+import com.atlassian.plugins.rest.api.security.annotation.UnrestrictedAccess;
 import com.atlassian.sal.api.ApplicationProperties;
 import com.atlassian.sal.api.UrlMode;
 
@@ -14,7 +14,7 @@ import javax.ws.rs.core.UriBuilder;
 import static javax.ws.rs.core.Response.Status.MOVED_PERMANENTLY;
 
 @Path("/settings")
-@AnonymousSiteAccess
+@UnrestrictedAccess
 public class SlackSettingsRedirectResource {
     private final ApplicationProperties applicationProperties;
 

--- a/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/rest/SlackWebHookResource.java
+++ b/slack-server-integration-common/src/main/java/com/atlassian/plugins/slack/rest/SlackWebHookResource.java
@@ -3,7 +3,7 @@ package com.atlassian.plugins.slack.rest;
 import com.atlassian.annotations.security.XsrfProtectionExcluded;
 import com.atlassian.confluence.compat.api.service.accessmode.ReadOnlyAccessAllowed;
 import com.atlassian.event.api.EventPublisher;
-import com.atlassian.plugins.rest.api.security.annotation.AnonymousSiteAccess;
+import com.atlassian.plugins.rest.api.security.annotation.UnrestrictedAccess;
 import com.atlassian.plugins.slack.analytics.AnalyticsContextProvider;
 import com.atlassian.plugins.slack.api.SlackLink;
 import com.atlassian.plugins.slack.api.events.SlackActionAnalyticEvent;
@@ -98,7 +98,7 @@ public class SlackWebHookResource {
     @POST
     @Path("/event")
     @Consumes(MediaType.APPLICATION_JSON)
-    @AnonymousSiteAccess
+    @UnrestrictedAccess
     @SlackSignatureVerifying
     public Response webEvent(@Context final HttpServletRequest request) {
         final JsonNode eventPayload;
@@ -175,7 +175,7 @@ public class SlackWebHookResource {
     @Path("/command")
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Produces(MediaType.APPLICATION_JSON)
-    @AnonymousSiteAccess
+    @UnrestrictedAccess
     @XsrfProtectionExcluded
     @SlackSignatureVerifying
     public Response slashCommand(
@@ -231,7 +231,7 @@ public class SlackWebHookResource {
     @Path("/action")
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Produces(MediaType.APPLICATION_JSON)
-    @AnonymousSiteAccess
+    @UnrestrictedAccess
     @XsrfProtectionExcluded
     @SlackSignatureVerifying
     public Response action(@FormParam("payload") String payload) {


### PR DESCRIPTION
Currently, the 5.x version of this plugin can't be connected to Bitbucket unless public access has been enabled on the Bitbucket instance. We just had a support case raised as a [result](https://getsupport.atlassian.com/browse/SSP-61430). 

A few endpoints in this plugin use `@AnonymousSiteAccess` instead of `@UnrestrictedAccess` annotations. This annotation was added during the [platform 7 adoption](https://github.com/atlassian-labs/atlassian-slack-integration-server/pull/370/files). More info about the annotations can be found [here](https://developer.atlassian.com/platform/marketplace/dc-apps-platform-7-preparing-for-secure-endpoints/). The current workaround is having a customer add `feature.public.access=true` and creating an empty repo that has public access, which is not ideal. 

I've built the plugin and confirmed I'm able to connect to bitbucket without enabling public access. 



 