### PR TITLE
DCPL-3677 exclude from processing messages from the bot itself

### DIFF
--- a/jira-slack-server-integration/jira-slack-server-integration-plugin/src/test/java/com/atlassian/jira/plugins/slack/service/listener/SlackEventListenerTest.java
+++ b/jira-slack-server-integration/jira-slack-server-integration-plugin/src/test/java/com/atlassian/jira/plugins/slack/service/listener/SlackEventListenerTest.java
@@ -315,6 +315,19 @@ public class SlackEventListenerTest {
     }
 
     @Test
+    public void messageReceived_doNothingIfMessageIsFromBotItself() {
+        when(slackEvent.getSlackLink()).thenReturn(link);
+        when(link.getBotUserId()).thenReturn("botUserId");
+        when(messageSlackEvent.getSlackEvent()).thenReturn(slackEvent);
+        when(messageSlackEvent.getUser()).thenReturn("botUserId");
+
+        target.messageReceived(messageSlackEvent);
+
+        verify(slackEventHandlerService, never()).handleMessage(any());
+        verify(taskBuilder, never()).newProcessMessageDeletionTask(any());
+    }
+
+    @Test
     public void linkShared() {
         when(linkSharedSlackEvent.getSlackEvent()).thenReturn(slackEvent);
         when(linkSharedSlackEvent.getChannel()).thenReturn("C");


### PR DESCRIPTION
prevent endless loops when bot user sends message that it doesn't understand command.
PSSRV-193036
hello page with title: PSSRV-193036 - Our slack Jira integration is not working despite the integration looking correct.

It will have to be either upmerged or cherry picked to the release-2.x branch/master