### PR TITLE
DCPL-3817: Don't bundle commons-beanutils

### DIFF
--- a/confluence-slack-integration/confluence-slack-server-integration-plugin/pom.xml
+++ b/confluence-slack-integration/confluence-slack-server-integration-plugin/pom.xml
@@ -71,6 +71,7 @@
             <groupId>commons-beanutils</groupId>
             <artifactId>commons-beanutils</artifactId>
             <version>1.11.0</version>
+            <scope>provided</scope>
             <exclusions>
                 <exclusion>
                     <groupId>commons-collections</groupId>


### PR DESCRIPTION
This is a banned dependency. 

`[INFO] --- confluence:9.5.4:validate-banned-dependencies (default-validate-banned-dependencies) @ confluence-slack-server-integration-plugin ---
[INFO] Dependencies excluded from banning: [com.atlassian.security:atlassian-secure-random, net.bytebuddy:byte-buddy, com.google.code.gson:gson]
[INFO] Scanning using platform version range: '[0,)'
Warning:  Rule 0: org.apache.maven.plugins.enforcer.BannedDependencies failed with message:
make sure platform artifacts are not bundled into plugin
Found Banned Dependency: commons-beanutils:commons-beanutils:jar:1.11.0`
