### PR TITLE
DCPL-3817: bitbucket -  Migrate to mockito 5

### DIFF
--- a/bitbucket-slack-server-integration-plugin/pom.xml
+++ b/bitbucket-slack-server-integration-plugin/pom.xml
@@ -55,7 +55,7 @@
         <atlassian.selenium.version>4.0.0</atlassian.selenium.version>
         <atlassian.plugin.point.safety.version>1.0.0</atlassian.plugin.point.safety.version>
         <junit.jupiter.version>5.13.4</junit.jupiter.version>
-        <mockito-core.version>2.25.0</mockito-core.version>
+        <mockito-core.version>5.21.0</mockito-core.version>
         <commons-codec.version>1.11</commons-codec.version>
         <slack.common.version>3.0.0</slack.common.version>
     </properties>

--- a/bitbucket-slack-server-integration-plugin/src/test/java/com/atlassian/bitbucket/plugins/slack/notification/renderer/SlackNotificationRendererTest.java
+++ b/bitbucket-slack-server-integration-plugin/src/test/java/com/atlassian/bitbucket/plugins/slack/notification/renderer/SlackNotificationRendererTest.java
@@ -70,6 +70,7 @@ import org.mockito.quality.Strictness;
 import org.mockito.stubbing.Answer;
 import org.mockito.stubbing.Answer1;
 
+import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -201,7 +202,7 @@ public class SlackNotificationRendererTest {
         when(slackLinkRenderer.refLink(repository, pullRequestToRef)).thenReturn(PR_TO_BRANCH_LINK);
 
         when(i18nResolver.getText(anyString())).thenAnswer(answer(key -> key));
-        when(i18nResolver.getText(anyString(), any()))
+        when(i18nResolver.getText(anyString(), any(Serializable[].class)))
                 .thenAnswer((Answer<String>) invocation -> join(invocation.getArguments()));
         when(commitService.getCommitsBetween(any(CommitsBetweenRequest.class), any(PageRequest.class))).thenReturn(page);
         when(refService.resolveRef(any())).thenReturn(ref);


### PR DESCRIPTION
Mockito 5 is a prerequisite for JDK 25.

The approach I'm taking is module-by-module migration.

